### PR TITLE
FE: fix redundant brackets for SerdeProperties

### DIFF
--- a/forward_engineering/helpers/tableHelper.js
+++ b/forward_engineering/helpers/tableHelper.js
@@ -221,7 +221,7 @@ const getRowFormat = (tableData) => {
 	}
 	if (tableData.rowFormat === 'SerDe') {
 		return buildStatement(`SERDE '${tableData.serDeLibrary}'`)
-			(tableData.serDeProperties, `WITH SERDEPROPERTIES (${tableData.serDeProperties})`)
+			(tableData.serDeProperties, `WITH SERDEPROPERTIES ${tableData.serDeProperties}`)
 			();
 	}
 


### PR DESCRIPTION
Seems that we already have brackets inside serdeproperties. Seems that we forgot remove brackets for Deltalake, because for Glue and Hive it's already removed