### PR TITLE
HCK-4144: reuse existing logic to wrap a name with backticks if needed

### DIFF
--- a/forward_engineering/helpers/databaseHelper.js
+++ b/forward_engineering/helpers/databaseHelper.js
@@ -31,7 +31,7 @@ const getUseCatalogStatement = (modelData, databaseData) => {
 	const databaseDetails = getTab(0, databaseData);
 
 	return databaseDetails.catalogName && isSupportUnityCatalog(modelDetails.dbVersion)
-		? `USE CATALOG \`${databaseDetails.catalogName}\`;`
+		? `USE CATALOG ${prepareName(databaseDetails.catalogName)};`
 		: '';
 };
 


### PR DESCRIPTION
Adjusted FE script generation for name of catalog in USE CATALOG statement to wrap in backticks only in case it is necessary.