### PR TITLE
Fix/hck 4339 fe-ing to file it should also provide the ability to set a number of rows to generate

### DIFF
--- a/forward_engineering/alterScript/alterScriptBuilder.js
+++ b/forward_engineering/alterScript/alterScriptBuilder.js
@@ -62,17 +62,14 @@ const doesEntityLevelAlterScriptContainDropStatements = (data, app) => (entityLe
  * @param app {App}
  * @return {(dto: ContainerLevelAlterScriptData) => Array<AlterScriptDto>}
  * */
-const getContainerLevelAlterScriptDtos = (data, app) => ({
-                                                             internalDefinitions,
-                                                             externalDefinitions,
-                                                             modelDefinitions,
-                                                             entitiesJsonSchema,
-                                                         }) => {
-    const _ = app.require('lodash');
-    const deltaModelSchema = _.first(Object.values(entitiesJsonSchema)) || {};
-    const definitions = [modelDefinitions, internalDefinitions, externalDefinitions];
-    return getAlterScriptDtos(deltaModelSchema, definitions, data, app);
-}
+const getContainerLevelAlterScriptDtos =
+	(data, app) =>
+	({ internalDefinitions, externalDefinitions, modelDefinitions, entitiesJsonSchema }) => {
+		const _ = app.require('lodash');
+		const deltaModelSchema = _.first(Object.values(entitiesJsonSchema)) || {};
+		const definitions = [modelDefinitions, internalDefinitions, externalDefinitions];
+		return getAlterScriptDtos(deltaModelSchema, definitions, data, app);
+	};
 
 /**
  * @param data {CoreData}

--- a/forward_engineering/api.js
+++ b/forward_engineering/api.js
@@ -36,9 +36,8 @@ const {
     getSampleGenerationOptions,
     parseJsonData,
     generateSampleForDemonstration,
-    generateSamplesScript
+    generateSamplesForEntity
 } = require("./sampleGeneration/sampleGenerationService");
-const {batchProcessFile} = require('../reverse_engineering/helpers/fileHelper');
 const {getDataForSampleGeneration} = require('./sampleGeneration/sampleGenerationService');
 
 /**
@@ -212,26 +211,14 @@ const getContainerScriptWithNotSeparateBuckets = async (app, data) => {
         return getScriptAndSampleResponse(scripts, demoSample);
     }
 
-    const samples = []
+    const sampleScripts = []
 
     for (const entityData of Object.values(parsedData.entitiesData || {})) {
-        const {filePath, jsonSchema, jsonData} = entityData;
-
-        const demoSample = generateSamplesScript(_)(jsonSchema, [jsonData])
-        samples.push(demoSample)
-
-        await batchProcessFile({
-            filePath,
-            batchSize: 1,
-            parseLine: line => JSON.parse(line),
-            batchHandler: async (batch) => {
-                const sample = generateSamplesScript(_)(jsonSchema, batch);
-                samples.push(sample)
-            },
-        })
+        const samples = await generateSamplesForEntity(_)(entityData);
+        sampleScripts.push(...samples);
     }
 
-    return getScriptAndSampleResponse(scripts, samples.join('\n\n'));
+    return getScriptAndSampleResponse(scripts, sampleScripts.join('\n\n'));
 }
 
 module.exports = {

--- a/forward_engineering/api.js
+++ b/forward_engineering/api.js
@@ -7,7 +7,11 @@ const fetchRequestHelper = require('../reverse_engineering/helpers/fetchRequestH
 const databricksHelper = require('../reverse_engineering/helpers/databricksHelper');
 
 const logHelper = require('../reverse_engineering/logHelper');
-const {buildEntityLevelFEScript, buildContainerLevelFEScriptDto, buildContainerLevelFEScript} = require("./helpers/feScriptBuilder");
+const {
+    buildEntityLevelFEScript,
+    buildContainerLevelFEScriptDto,
+    buildContainerLevelFEScript
+} = require("./helpers/feScriptBuilder");
 const {
     buildEntityLevelAlterScript,
     buildContainerLevelAlterScript,
@@ -28,9 +32,14 @@ const {
     Logger,
     PluginError
 } = require('./types/coreApplicationTypes')
-const {getSampleGenerationOptions, parseJsonData, generateSampleForDemonstration, generateSamplesScript} = require("./sampleGeneration/sampleGenerationService");
-const { batchProcessFile } = require('../reverse_engineering/helpers/fileHelper');
-const { getDataForSampleGeneration } = require('./sampleGeneration/sampleGenerationService');
+const {
+    getSampleGenerationOptions,
+    parseJsonData,
+    generateSampleForDemonstration,
+    generateSamplesScript
+} = require("./sampleGeneration/sampleGenerationService");
+const {batchProcessFile} = require('../reverse_engineering/helpers/fileHelper');
+const {getDataForSampleGeneration} = require('./sampleGeneration/sampleGenerationService');
 
 /**
  * @typedef {(error?: PluginError | null, result?: any | null) => void} PluginCallback
@@ -101,31 +110,31 @@ const parseDataForEntityLevelScript = (data) => {
  *      externalDefinitions: ExternalDefinitions | unknown,
  *      containerData: ContainerData | unknown,
  *      entitiesJsonSchema: EntitiesJsonSchema | unknown,
- *      jsonData: Record<string, Object>
+ *      jsonData: Record<string, Object>,
  *      entitiesData: EntitiesData,
  *      isInvokedFromApplyToInstance: boolean,
  * }}
  * */
 const parseDataForContainerLevelScript = data => {
-	const modelData = data.modelData;
-	const containerData = data.containerData;
-	const modelDefinitions = JSON.parse(data.modelDefinitions);
-	const externalDefinitions = JSON.parse(data.externalDefinitions);
-	const entitiesJsonSchema = parseEntities(data.entities, data.jsonSchema);
-	const internalDefinitions = parseEntities(data.entities, data.internalDefinitions);
-	const { jsonData, entitiesData, isInvokedFromApplyToInstance } = getDataForSampleGeneration(data, entitiesJsonSchema);
+    const modelData = data.modelData;
+    const containerData = data.containerData;
+    const modelDefinitions = JSON.parse(data.modelDefinitions);
+    const externalDefinitions = JSON.parse(data.externalDefinitions);
+    const entitiesJsonSchema = parseEntities(data.entities, data.jsonSchema);
+    const internalDefinitions = parseEntities(data.entities, data.internalDefinitions);
+    const {jsonData, entitiesData, isInvokedFromApplyToInstance} = getDataForSampleGeneration(data, entitiesJsonSchema);
 
-	return {
-		modelData,
-		modelDefinitions,
-		internalDefinitions,
-		externalDefinitions,
-		containerData,
-		entitiesJsonSchema,
-		jsonData,
+    return {
+        modelData,
+        modelDefinitions,
+        internalDefinitions,
+        externalDefinitions,
+        containerData,
+        entitiesJsonSchema,
+        jsonData,
         entitiesData,
         isInvokedFromApplyToInstance,
-	};
+    };
 };
 
 /**
@@ -199,14 +208,14 @@ const getContainerScriptWithNotSeparateBuckets = async (app, data) => {
 
     if (parsedData.isInvokedFromApplyToInstance) {
         const demoSample = generateSampleForDemonstration(app, parsedData, 'container');
-        
+
         return getScriptAndSampleResponse(scripts, demoSample);
     }
 
     const samples = []
 
     for (const entityData of Object.values(parsedData.entitiesData || {})) {
-        const { filePath, jsonSchema, jsonData } = entityData;
+        const {filePath, jsonSchema, jsonData} = entityData;
 
         const demoSample = generateSamplesScript(_)(jsonSchema, [jsonData])
         samples.push(demoSample)
@@ -216,10 +225,10 @@ const getContainerScriptWithNotSeparateBuckets = async (app, data) => {
             batchSize: 1,
             parseLine: line => JSON.parse(line),
             batchHandler: async (batch) => {
-               const sample = generateSamplesScript(_)(jsonSchema, batch);
-               samples.push(sample)
+                const sample = generateSamplesScript(_)(jsonSchema, batch);
+                samples.push(sample)
             },
-         })
+        })
     }
 
     return getScriptAndSampleResponse(scripts, samples.join('\n\n'));

--- a/forward_engineering/api.js
+++ b/forward_engineering/api.js
@@ -111,7 +111,6 @@ const parseDataForEntityLevelScript = (data) => {
  *      entitiesJsonSchema: EntitiesJsonSchema | unknown,
  *      jsonData: Record<string, Object>,
  *      entitiesData: EntitiesData,
- *      isInvokedFromApplyToInstance: boolean,
  * }}
  * */
 const parseDataForContainerLevelScript = data => {
@@ -121,7 +120,7 @@ const parseDataForContainerLevelScript = data => {
     const externalDefinitions = JSON.parse(data.externalDefinitions);
     const entitiesJsonSchema = parseEntities(data.entities, data.jsonSchema);
     const internalDefinitions = parseEntities(data.entities, data.internalDefinitions);
-    const {jsonData, entitiesData, isInvokedFromApplyToInstance} = getDataForSampleGeneration(data, entitiesJsonSchema);
+    const {jsonData, entitiesData} = getDataForSampleGeneration(data, entitiesJsonSchema);
 
     return {
         modelData,
@@ -132,7 +131,6 @@ const parseDataForContainerLevelScript = data => {
         entitiesJsonSchema,
         jsonData,
         entitiesData,
-        isInvokedFromApplyToInstance,
     };
 };
 
@@ -205,7 +203,7 @@ const getContainerScriptWithNotSeparateBuckets = async (app, data) => {
         return scripts;
     }
 
-    if (parsedData.isInvokedFromApplyToInstance) {
+    if (parsedData.jsonData) {
         const demoSample = generateSampleForDemonstration(app, parsedData, 'container');
 
         return getScriptAndSampleResponse(scripts, demoSample);

--- a/forward_engineering/api.js
+++ b/forward_engineering/api.js
@@ -110,7 +110,7 @@ const parseDataForEntityLevelScript = (data) => {
  *      containerData: ContainerData | unknown,
  *      entitiesJsonSchema: EntitiesJsonSchema | unknown,
  *      jsonData: Record<string, Object>,
- *      entitiesData: EntitiesData,
+ *      entitiesData: EntitiesData | undefined,
  * }}
  * */
 const parseDataForContainerLevelScript = data => {

--- a/forward_engineering/config.json
+++ b/forward_engineering/config.json
@@ -22,6 +22,9 @@
 	"applyToInstanceSettings": {
 		"generateSamplesInBulk": true
 	},
+	"forwardEngineeringSettings": {
+		"generateSamplesInBulk": true
+	},
 	"additionalOptions": [
 		{
 			"id": "applyDropStatements",
@@ -38,7 +41,9 @@
 		}
 	],
 	"splitView": {
-		"byAdditionalOptions": ["INCLUDE_SAMPLES"]
+		"byAdditionalOptions": [
+			"INCLUDE_SAMPLES"
+		]
 	},
 	"numberOfDocumentsOptions": {
 		"id": "numberOfDocuments",

--- a/forward_engineering/config.json
+++ b/forward_engineering/config.json
@@ -22,9 +22,7 @@
 	"applyToInstanceSettings": {
 		"generateSamplesInBulk": true
 	},
-	"forwardEngineeringSettings": {
-		"generateSamplesInBulk": true
-	},
+	"generateSamplesInBulk": true,
 	"additionalOptions": [
 		{
 			"id": "applyDropStatements",

--- a/forward_engineering/helpers/feScriptBuilder.js
+++ b/forward_engineering/helpers/feScriptBuilder.js
@@ -67,14 +67,14 @@ const {batchProcessFile} = require('../../reverse_engineering/helpers/fileHelper
  * @return {(dto: EntityLevelFEScriptData) => string}
  * */
 const buildEntityLevelFEScript = (data, app) => ({
-                                                     externalDefinitions,
-                                                     modelDefinitions,
-                                                     jsonSchema,
-                                                     internalDefinitions,
-                                                     containerData,
-                                                     entityData,
-                                                     modelData,
-                                                 }) => {
+    externalDefinitions,
+    modelDefinitions,
+    jsonSchema,
+    internalDefinitions,
+    containerData,
+    entityData,
+    modelData,
+}) => {
     const _ = app.require('lodash');
     const dbVersion = data.modelData[0].dbVersion;
     const arePkFkConstraintsAvailable = isSupportUnityCatalog(dbVersion);
@@ -144,11 +144,11 @@ const getContainerLevelViewScriptDtos = (data, _) => {
  * }) => Promise<string>}
  */
 const getSampleScriptForContainerLevelScript = (_) => async ({
-                                                                 data,
-                                                                 includeSamplesInEntityScripts,
-                                                                 entitiesJsonSchema,
-                                                                 entityId
-                                                             }) => {
+    data,
+    includeSamplesInEntityScripts,
+    entitiesJsonSchema,
+    entityId
+}) => {
     const sampleScripts = [];
     if (includeSamplesInEntityScripts) {
         const {jsonData, entitiesData} = getDataForSampleGeneration(data, entitiesJsonSchema);

--- a/forward_engineering/helpers/feScriptBuilder.js
+++ b/forward_engineering/helpers/feScriptBuilder.js
@@ -187,16 +187,16 @@ const getSampleScriptForContainerLevelScript = (_) => async ({
  * @return {(data: ContainerLevelFEScriptData) => Promise<Array<ContainerLevelEntityDto>>}
  * */
 const getContainerLevelEntitiesScriptDtos = (app, data) => async ({
-                                                                      externalDefinitions,
-                                                                      modelDefinitions,
-                                                                      internalDefinitions,
-                                                                      containerData,
-                                                                      entitiesJsonSchema,
-                                                                      arePkFkConstraintsAvailable,
-                                                                      areNotNullConstraintsAvailable,
-                                                                      includeRelationshipsInEntityScripts,
-                                                                      includeSamplesInEntityScripts,
-                                                                  }) => {
+    externalDefinitions,
+    modelDefinitions,
+    internalDefinitions,
+    containerData,
+    entitiesJsonSchema,
+    arePkFkConstraintsAvailable,
+    areNotNullConstraintsAvailable,
+    includeRelationshipsInEntityScripts,
+    includeSamplesInEntityScripts,
+}) => {
     const _ = app.require('lodash');
     const scriptDtos = [];
 
@@ -267,14 +267,14 @@ const getContainerLevelEntitiesScriptDtos = (app, data) => async ({
  * }>}
  * */
 const buildContainerLevelFEScriptDto = (data, app) => async ({
-                                                                 internalDefinitions,
-                                                                 externalDefinitions,
-                                                                 modelDefinitions,
-                                                                 entitiesJsonSchema,
-                                                                 containerData,
-                                                                 includeRelationshipsInEntityScripts,
-                                                                 includeSamplesInEntityScripts,
-                                                             }) => {
+    internalDefinitions,
+    externalDefinitions,
+    modelDefinitions,
+    entitiesJsonSchema,
+    containerData,
+    includeRelationshipsInEntityScripts,
+    includeSamplesInEntityScripts,
+}) => {
     const _ = app.require('lodash');
     const dbVersion = data.modelData[0].dbVersion;
     const arePkFkConstraintsAvailable = isSupportUnityCatalog(dbVersion);

--- a/forward_engineering/helpers/feScriptBuilder.js
+++ b/forward_engineering/helpers/feScriptBuilder.js
@@ -34,8 +34,7 @@ const {getTableStatement} = require("./tableHelper");
 const {getIndexes} = require("./indexHelper");
 const {buildScript, getName, getTab, isSupportUnityCatalog, isSupportNotNullConstraints} = require("../utils/general");
 const {getViewScript} = require("./viewHelper");
-const {generateSamplesScript, getDataForSampleGeneration} = require('../sampleGeneration/sampleGenerationService');
-const {batchProcessFile} = require('../../reverse_engineering/helpers/fileHelper');
+const {generateSamplesScript, getDataForSampleGeneration, generateSamplesForEntity} = require('../sampleGeneration/sampleGenerationService');
 
 /**
  * @typedef {{
@@ -160,20 +159,8 @@ const getSampleScriptForContainerLevelScript = (_) => async ({
         }
         if (entitiesData) {
             const entityData = entitiesData[entityId];
-            const {filePath, jsonSchema, jsonData} = entityData;
-
-            const demoSample = generateSamplesScript(_)(jsonSchema, [jsonData]);
-            sampleScripts.push(demoSample);
-
-            await batchProcessFile({
-                filePath,
-                batchSize: 1,
-                parseLine: line => JSON.parse(line),
-                batchHandler: async batch => {
-                    const sample = generateSamplesScript(_)(jsonSchema, batch);
-                    sampleScripts.push(sample);
-                },
-            });
+            const samples = await generateSamplesForEntity(_)(entityData);
+            sampleScripts.push(...samples);
         }
     }
 

--- a/forward_engineering/helpers/feScriptBuilder.js
+++ b/forward_engineering/helpers/feScriptBuilder.js
@@ -35,7 +35,7 @@ const {getIndexes} = require("./indexHelper");
 const {buildScript, getName, getTab, isSupportUnityCatalog, isSupportNotNullConstraints} = require("../utils/general");
 const {getViewScript} = require("./viewHelper");
 const {generateSamplesScript, getDataForSampleGeneration} = require('../sampleGeneration/sampleGenerationService');
-const { batchProcessFile } = require('../../reverse_engineering/helpers/fileHelper');
+const {batchProcessFile} = require('../../reverse_engineering/helpers/fileHelper');
 
 /**
  * @typedef {{
@@ -55,8 +55,6 @@ const { batchProcessFile } = require('../../reverse_engineering/helpers/fileHelp
  *     modelDefinitions: ModelDefinitions,
  *     internalDefinitions: InternalDefinitions,
  *     containerData: ContainerData,
- *     arePkFkConstraintsAvailable: boolean,
- *     areNotNullConstraintsAvailable: boolean,
  *     includeRelationshipsInEntityScripts: boolean,
  *     entitiesJsonSchema: EntitiesJsonSchema,
  *     includeSamplesInEntityScripts: boolean,
@@ -69,14 +67,14 @@ const { batchProcessFile } = require('../../reverse_engineering/helpers/fileHelp
  * @return {(dto: EntityLevelFEScriptData) => string}
  * */
 const buildEntityLevelFEScript = (data, app) => ({
-    externalDefinitions,
-    modelDefinitions,
-    jsonSchema,
-    internalDefinitions,
-    containerData,
-    entityData,
-    modelData,
-}) => {
+                                                     externalDefinitions,
+                                                     modelDefinitions,
+                                                     jsonSchema,
+                                                     internalDefinitions,
+                                                     containerData,
+                                                     entityData,
+                                                     modelData,
+                                                 }) => {
     const _ = app.require('lodash');
     const dbVersion = data.modelData[0].dbVersion;
     const arePkFkConstraintsAvailable = isSupportUnityCatalog(dbVersion);
@@ -139,42 +137,47 @@ const getContainerLevelViewScriptDtos = (data, _) => {
 /**
  * @param _ {any}
  * @return {({
- * data: CoreData,
- * includeSamplesInEntityScripts: boolean,
- * entitiesJsonSchema: Record<string, Object>,
- * entityId: string,
+ *      data: CoreData,
+ *      includeSamplesInEntityScripts: boolean,
+ *      entitiesJsonSchema: Record<string, Object>,
+ *      entityId: string,
  * }) => Promise<string>}
-*/
-const getSampleScriptForContainerLevelScript = (_) => async ({data, includeSamplesInEntityScripts, entitiesJsonSchema, entityId}) => {
-	const sampleScripts = [];
-	if (includeSamplesInEntityScripts) {
-		const { jsonData, entitiesData } = getDataForSampleGeneration(data, entitiesJsonSchema);
-		const entityJsonSchema = entitiesJsonSchema[entityId] || {};
-		if (jsonData) {
-			const demoSampleJsonData = jsonData[entityId] || {};
-			const demoSample = generateSamplesScript(_)(entityJsonSchema, [demoSampleJsonData]);
-			sampleScripts.push(demoSample);
-		}
-		if (entitiesData) {
-			const entityData = entitiesData[entityId];
-			const { filePath, jsonSchema, jsonData } = entityData;
+ */
+const getSampleScriptForContainerLevelScript = (_) => async ({
+                                                                 data,
+                                                                 includeSamplesInEntityScripts,
+                                                                 entitiesJsonSchema,
+                                                                 entityId
+                                                             }) => {
+    const sampleScripts = [];
+    if (includeSamplesInEntityScripts) {
+        const {jsonData, entitiesData} = getDataForSampleGeneration(data, entitiesJsonSchema);
+        const entityJsonSchema = entitiesJsonSchema[entityId] || {};
+        if (jsonData) {
+            const demoSampleJsonData = jsonData[entityId] || {};
+            const demoSample = generateSamplesScript(_)(entityJsonSchema, [demoSampleJsonData]);
+            sampleScripts.push(demoSample);
+        }
+        if (entitiesData) {
+            const entityData = entitiesData[entityId];
+            const {filePath, jsonSchema, jsonData} = entityData;
 
-			const demoSample = generateSamplesScript(_)(jsonSchema, [jsonData]);
-			sampleScripts.push(demoSample);
+            const demoSample = generateSamplesScript(_)(jsonSchema, [jsonData]);
+            sampleScripts.push(demoSample);
 
-			await batchProcessFile({
-				filePath,
-				batchSize: 1,
-				parseLine: line => JSON.parse(line),
-				batchHandler: async batch => {
-					const sample = generateSamplesScript(_)(jsonSchema, batch);
-					sampleScripts.push(sample);
-				},
-			});
-		}
-	}
+            await batchProcessFile({
+                filePath,
+                batchSize: 1,
+                parseLine: line => JSON.parse(line),
+                batchHandler: async batch => {
+                    const sample = generateSamplesScript(_)(jsonSchema, batch);
+                    sampleScripts.push(sample);
+                },
+            });
+        }
+    }
 
-	return sampleScripts.join('\n\n');
+    return sampleScripts.join('\n\n');
 }
 
 
@@ -184,64 +187,64 @@ const getSampleScriptForContainerLevelScript = (_) => async ({data, includeSampl
  * @return {(data: ContainerLevelFEScriptData) => Promise<Array<ContainerLevelEntityDto>>}
  * */
 const getContainerLevelEntitiesScriptDtos = (app, data) => async ({
-    externalDefinitions,
-    modelDefinitions,
-    internalDefinitions,
-    containerData,
-    entitiesJsonSchema,
-    arePkFkConstraintsAvailable,
-    areNotNullConstraintsAvailable,
-    includeRelationshipsInEntityScripts,
-    includeSamplesInEntityScripts,
-}) => {
-	const _ = app.require('lodash');
-	const scriptDtos = [];
+                                                                      externalDefinitions,
+                                                                      modelDefinitions,
+                                                                      internalDefinitions,
+                                                                      containerData,
+                                                                      entitiesJsonSchema,
+                                                                      arePkFkConstraintsAvailable,
+                                                                      areNotNullConstraintsAvailable,
+                                                                      includeRelationshipsInEntityScripts,
+                                                                      includeSamplesInEntityScripts,
+                                                                  }) => {
+    const _ = app.require('lodash');
+    const scriptDtos = [];
 
-	for (const entityId of data.entities) {
-		const entityData = data.entityData[entityId];
+    for (const entityId of data.entities) {
+        const entityData = data.entityData[entityId];
 
-		const likeTableData = data.entityData[getTab(0, entityData)?.like];
-		const entityJsonSchema = entitiesJsonSchema[entityId];
-		const definitions = [internalDefinitions[entityId], modelDefinitions, externalDefinitions];
-		const createTableStatementArgs = [containerData, entityData, entityJsonSchema, definitions];
+        const likeTableData = data.entityData[getTab(0, entityData)?.like];
+        const entityJsonSchema = entitiesJsonSchema[entityId];
+        const definitions = [internalDefinitions[entityId], modelDefinitions, externalDefinitions];
+        const createTableStatementArgs = [containerData, entityData, entityJsonSchema, definitions];
 
-		const tableStatement = getTableStatement(app)(
-			...createTableStatementArgs,
-			arePkFkConstraintsAvailable,
-			areNotNullConstraintsAvailable,
-			likeTableData,
-		);
+        const tableStatement = getTableStatement(app)(
+            ...createTableStatementArgs,
+            arePkFkConstraintsAvailable,
+            areNotNullConstraintsAvailable,
+            likeTableData,
+        );
 
-		const indexScript = getIndexes(_)(...createTableStatementArgs);
+        const indexScript = getIndexes(_)(...createTableStatementArgs);
 
-		let relationshipScripts = [];
-		if (includeRelationshipsInEntityScripts && arePkFkConstraintsAvailable) {
-			const relationshipsWithThisTableAsChild = data.relationships.filter(
-				relationship => relationship.childCollection === entityId,
-			);
-			relationshipScripts = getCreateRelationshipScripts(app)(relationshipsWithThisTableAsChild, entitiesJsonSchema);
-		}
+        let relationshipScripts = [];
+        if (includeRelationshipsInEntityScripts && arePkFkConstraintsAvailable) {
+            const relationshipsWithThisTableAsChild = data.relationships.filter(
+                relationship => relationship.childCollection === entityId,
+            );
+            relationshipScripts = getCreateRelationshipScripts(app)(relationshipsWithThisTableAsChild, entitiesJsonSchema);
+        }
 
-		const sampleScript = await getSampleScriptForContainerLevelScript(_)({
-			data,
-			entitiesJsonSchema,
-			entityId,
-			includeSamplesInEntityScripts,
-		});
+        const sampleScript = await getSampleScriptForContainerLevelScript(_)({
+            data,
+            entitiesJsonSchema,
+            entityId,
+            includeSamplesInEntityScripts,
+        });
 
-		let tableScript = buildScript([tableStatement, indexScript, ...relationshipScripts]);
-		if (sampleScript) {
-			// This is because SQL formatter breaks some "INSERT" statements with complex types
-			tableScript = [tableScript, sampleScript].join('\n');
-		}
+        let tableScript = buildScript([tableStatement, indexScript, ...relationshipScripts]);
+        if (sampleScript) {
+            // This is because SQL formatter breaks some "INSERT" statements with complex types
+            tableScript = [tableScript, sampleScript].join('\n');
+        }
 
-		scriptDtos.push({
-			name: getName(entityData[0]),
-			script: tableScript,
-		});
-	}
+        scriptDtos.push({
+            name: getName(entityData[0]),
+            script: tableScript,
+        });
+    }
 
-	return scriptDtos;
+    return scriptDtos;
 }
 
 /**
@@ -264,14 +267,14 @@ const getContainerLevelEntitiesScriptDtos = (app, data) => async ({
  * }>}
  * */
 const buildContainerLevelFEScriptDto = (data, app) => async ({
-    internalDefinitions,
-    externalDefinitions,
-    modelDefinitions,
-    entitiesJsonSchema,
-    containerData,
-    includeRelationshipsInEntityScripts,
-    includeSamplesInEntityScripts,
-}) => {
+                                                                 internalDefinitions,
+                                                                 externalDefinitions,
+                                                                 modelDefinitions,
+                                                                 entitiesJsonSchema,
+                                                                 containerData,
+                                                                 includeRelationshipsInEntityScripts,
+                                                                 includeSamplesInEntityScripts,
+                                                             }) => {
     const _ = app.require('lodash');
     const dbVersion = data.modelData[0].dbVersion;
     const arePkFkConstraintsAvailable = isSupportUnityCatalog(dbVersion);

--- a/forward_engineering/sampleGeneration/sampleGenerationService.js
+++ b/forward_engineering/sampleGeneration/sampleGenerationService.js
@@ -193,19 +193,16 @@ const generateSamplesScript = (_) => (entityJsonSchema, samples) => {
  * @param {CoreData} data 
  * @param {{[id: string]: EntityJsonSchema}} entitiesJsonSchema 
  * @return {{
- * jsonData: ParsedJsonData,
- * entitiesData: EntitiesData,
- * isInvokedFromApplyToInstance: boolean
+ * jsonData: ParsedJsonData | undefined,
+ * entitiesData: EntitiesData | undefined,
  * }}
  */
 const getDataForSampleGeneration = (data, entitiesJsonSchema) => {
 	let jsonData = undefined;
 	let entitiesData = undefined;
-	let isInvokedFromApplyToInstance = false;
 
 	if (!data.entitiesData) {
 		jsonData = parseJsonData(data.jsonData);
-		isInvokedFromApplyToInstance = true;
 	} else {
 		entitiesData = {};
 		for (const key of Object.keys(data.entitiesData)) {
@@ -218,7 +215,7 @@ const getDataForSampleGeneration = (data, entitiesJsonSchema) => {
 		}
 	}
 
-	return { jsonData, entitiesData, isInvokedFromApplyToInstance };
+	return { jsonData, entitiesData };
 };
 /**
  * @param {EntityData} entityData 

--- a/forward_engineering/sampleGeneration/sampleGenerationTypes.d.ts
+++ b/forward_engineering/sampleGeneration/sampleGenerationTypes.d.ts
@@ -1,3 +1,4 @@
+import { EntityJsonSchema } from "../types/coreApplicationDataTypes";
 import {ModelTypes} from "../types/modelTypes";
 
 export type EntityLevelParsedJsonData = {
@@ -20,3 +21,13 @@ export type SampleGenerationEntityJsonSchema = {
         }
     }
 }
+
+export type EntitiesData = {
+	[id: string]: {
+		name: string;
+		code: string | undefined;
+		jsonData: string;
+		filePath?: string;
+		jsonSchema?: EntityJsonSchema;
+	};
+};

--- a/forward_engineering/sampleGeneration/sampleGenerationTypes.d.ts
+++ b/forward_engineering/sampleGeneration/sampleGenerationTypes.d.ts
@@ -22,12 +22,14 @@ export type SampleGenerationEntityJsonSchema = {
     }
 }
 
+export type EntityData = {
+    name: string;
+    code: string | undefined;
+    jsonData: string;
+    filePath?: string;
+    jsonSchema?: EntityJsonSchema;
+}
+
 export type EntitiesData = {
-	[id: string]: {
-		name: string;
-		code: string | undefined;
-		jsonData: string;
-		filePath?: string;
-		jsonSchema?: EntityJsonSchema;
-	};
+	[id: string]: EntityData;
 };

--- a/forward_engineering/types/coreApplicationTypes.js
+++ b/forward_engineering/types/coreApplicationTypes.js
@@ -68,6 +68,11 @@ class CoreData {
     entities
 
     /**
+     * @type {any}
+     */
+    entitiesData
+
+    /**
      * @type {Array<any>}
      */
     views

--- a/forward_engineering/types/coreApplicationTypes.js
+++ b/forward_engineering/types/coreApplicationTypes.js
@@ -72,7 +72,7 @@ class CoreData {
     entities
 
     /**
-     * @type {EntitiesData}
+     * @type {EntitiesData | undefined}
      */
     entitiesData
 

--- a/forward_engineering/types/coreApplicationTypes.js
+++ b/forward_engineering/types/coreApplicationTypes.js
@@ -1,3 +1,7 @@
+/**
+ * @typedef {import('../sampleGeneration/sampleGenerationTypes').EntitiesData} EntitiesData
+ * */
+
 class PluginError {
     /**
      * @type string
@@ -68,7 +72,7 @@ class CoreData {
     entities
 
     /**
-     * @type {any}
+     * @type {EntitiesData}
      */
     entitiesData
 

--- a/reverse_engineering/helpers/fileHelper.js
+++ b/reverse_engineering/helpers/fileHelper.js
@@ -35,12 +35,12 @@ const getCountOfLines = filePath => {
  * @param batchHandler {(batch: Array<any>) => Promise<void>}
  * */
 const batchProcessFile = async ({
-                                    filePath,
-                                    batchSize,
-                                    parseLine = (l) => l,
-                                    batchHandler = async (batch) => {},
-                                    logProgress = (lineIndex, amountOfLines) => {},
-                                }) => {
+    filePath,
+    batchSize,
+    parseLine = (l) => l,
+    batchHandler = async (batch) => {},
+    logProgress = (lineIndex, amountOfLines) => {},
+}) => {
     if (!filePath) {
         return;
     }


### PR DESCRIPTION
## Technical details

Added a new flag `generateSamplesInBulk` that controls the display of the input field for the number of generated samples in the FE modal window for the target script, if the "Include samples" checkbox is checked.
From the application in this case, a property `entitiesData` in the `data` argument is passed to the API methods for generating FE-ing scripts, containing the path to a file in the temporary folder with the generated samples. It is processed by the `getDataForSampleGeneration` function and, unless undefined, the samples will be generated by the `generateSamplesForEntity` function.