### PR TITLE
HCK-4420: Add null safety check to filtering check constraints

### DIFF
--- a/forward_engineering/helpers/entityHelpers/checkConstraintHelper.js
+++ b/forward_engineering/helpers/entityHelpers/checkConstraintHelper.js
@@ -35,7 +35,7 @@ const getCheckConstraintName = (constraintName, tableName, index) => {
 const getCheckConstraintsScriptsOnColumnLevel = (ddlProvider) => (columns, tableName) => {
 	return Object.keys(columns)
 		.map(colName => ({ colName: colName.replaceAll('`', ''), ...columns[colName] }))
-		.filter(column => column.constraints.check)
+		.filter(column => column.constraints?.check)
 		.map(column => {
 			const constraintName = getCheckConstraintName(column.constraints.checkConstraintName, tableName);
 


### PR DESCRIPTION
Add a simple null safety check while filtering check constraints. Thus preventing possible error.