### PR TITLE
HCK-4487: allow FE of FK relationships for tables without a schema

### DIFF
--- a/forward_engineering/helpers/relationshipHelper.js
+++ b/forward_engineering/helpers/relationshipHelper.js
@@ -45,7 +45,7 @@ const createSingleRelationship = (_, ddlProvider) => (relationship, entitiesJson
     const childBucketName = prepareName(childTable?.bucketName);
     const parentBucketName = prepareName(parentTable?.bucketName);
 
-    if (!parentTable || !childTable || !childBucketName || !parentBucketName) {
+    if (!parentTable || !childTable) {
         return '';
     }
     const childFieldIds = getChildFieldIds(relationship);


### PR DESCRIPTION
Include FK relationships into FE-d DDL even if the tables are without a schema.