### PR TITLE
HCK-4544:  display varchar max length on the diagram

### DIFF
--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -168,7 +168,21 @@ making sure that you maintain a proper JSON format.
 			"format",
 			"pattern",
 			"minLength",
-			"maxLength",
+			{
+				"propertyName": "Max length",
+				"propertyKeyword": "maxLength",
+				"propertyType": "numeric",
+				"shouldValidate": true,
+				"allowNegative": false,
+				"valueType": "number",
+				"typeDecorator": {
+					"useAngleBrackets": false,
+					"dependency": {
+						"key": "mode",
+						"value": "varchar"
+					}
+				}
+			},
 			"enum",
 			{
 				"propertyName": "Not null",


### PR DESCRIPTION
Display max length for varchar subtype on the diagram

![image](https://github.com/hackolade/DeltaLake/assets/17798340/dd95f49b-cc0d-4f7e-97a9-2d475c4d3ae8)
