### PR TITLE
HCK-8740: Add composite PK/UK to FE

### DIFF
--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -218,6 +218,7 @@ making sure that you maintain a proper JSON format.
 			{
 				"propertyName": "Primary key",
 				"propertyKeyword": "compositePrimaryKey",
+				"propertyNameFull": "Composite Primary Key",
 				"propertyType": "checkbox",
 				"propertyTooltip": {
 					"disabled": [
@@ -379,6 +380,7 @@ making sure that you maintain a proper JSON format.
 			{
 				"propertyName": "Unique",
 				"propertyKeyword": "compositeUniqueKey",
+				"propertyNameFull": "Composite Unique Key",
 				"propertyType": "checkbox",
 				"dependency": {
 					"key": "compositeUniqueKey",
@@ -629,6 +631,7 @@ making sure that you maintain a proper JSON format.
 			{
 				"propertyName": "Primary key",
 				"propertyKeyword": "compositePrimaryKey",
+				"propertyNameFull": "Composite Primary Key",
 				"propertyType": "checkbox",
 				"propertyTooltip": {
 					"disabled": [
@@ -716,6 +719,7 @@ making sure that you maintain a proper JSON format.
 			{
 				"propertyName": "Unique",
 				"propertyKeyword": "compositeUniqueKey",
+				"propertyNameFull": "Composite Unique Key",
 				"propertyType": "checkbox",
 				"dependency": {
 					"key": "compositeUniqueKey",
@@ -1120,6 +1124,7 @@ making sure that you maintain a proper JSON format.
 			{
 				"propertyName": "Primary key",
 				"propertyKeyword": "compositePrimaryKey",
+				"propertyNameFull": "Composite Primary Key",
 				"propertyType": "checkbox",
 				"propertyTooltip": {
 					"disabled": [
@@ -1207,6 +1212,7 @@ making sure that you maintain a proper JSON format.
 			{
 				"propertyName": "Unique",
 				"propertyKeyword": "compositeUniqueKey",
+				"propertyNameFull": "Composite Unique Key",
 				"propertyType": "checkbox",
 				"dependency": {
 					"key": "compositeUniqueKey",
@@ -1439,6 +1445,7 @@ making sure that you maintain a proper JSON format.
 			{
 				"propertyName": "Primary key",
 				"propertyKeyword": "compositePrimaryKey",
+				"propertyNameFull": "Composite Primary Key",
 				"propertyType": "checkbox",
 				"propertyTooltip": {
 					"disabled": [
@@ -1526,6 +1533,7 @@ making sure that you maintain a proper JSON format.
 			{
 				"propertyName": "Unique",
 				"propertyKeyword": "compositeUniqueKey",
+				"propertyNameFull": "Composite Unique Key",
 				"propertyType": "checkbox",
 				"dependency": {
 					"key": "compositeUniqueKey",
@@ -1741,6 +1749,7 @@ making sure that you maintain a proper JSON format.
 			{
 				"propertyName": "Primary key",
 				"propertyKeyword": "compositePrimaryKey",
+				"propertyNameFull": "Composite Primary Key",
 				"propertyType": "checkbox",
 				"propertyTooltip": {
 					"disabled": [
@@ -1828,6 +1837,7 @@ making sure that you maintain a proper JSON format.
 			{
 				"propertyName": "Unique",
 				"propertyKeyword": "compositeUniqueKey",
+				"propertyNameFull": "Composite Unique Key",
 				"propertyType": "checkbox",
 				"dependency": {
 					"key": "compositeUniqueKey",
@@ -2042,6 +2052,7 @@ making sure that you maintain a proper JSON format.
 			{
 				"propertyName": "Primary key",
 				"propertyKeyword": "compositePrimaryKey",
+				"propertyNameFull": "Composite Primary Key",
 				"propertyType": "checkbox",
 				"propertyTooltip": {
 					"disabled": [
@@ -2129,6 +2140,7 @@ making sure that you maintain a proper JSON format.
 			{
 				"propertyName": "Unique",
 				"propertyKeyword": "compositeUniqueKey",
+				"propertyNameFull": "Composite Unique Key",
 				"propertyType": "checkbox",
 				"dependency": {
 					"key": "compositeUniqueKey",
@@ -2363,6 +2375,7 @@ making sure that you maintain a proper JSON format.
 			{
 				"propertyName": "Primary key",
 				"propertyKeyword": "compositePrimaryKey",
+				"propertyNameFull": "Composite Primary Key",
 				"propertyType": "checkbox",
 				"propertyTooltip": {
 					"disabled": [
@@ -2450,6 +2463,7 @@ making sure that you maintain a proper JSON format.
 			{
 				"propertyName": "Unique",
 				"propertyKeyword": "compositeUniqueKey",
+				"propertyNameFull": "Composite Unique Key",
 				"propertyType": "checkbox",
 				"dependency": {
 					"key": "compositeUniqueKey",
@@ -2705,6 +2719,7 @@ making sure that you maintain a proper JSON format.
 			{
 				"propertyName": "Primary key",
 				"propertyKeyword": "compositePrimaryKey",
+				"propertyNameFull": "Composite Primary Key",
 				"propertyType": "checkbox",
 				"propertyTooltip": {
 					"disabled": [
@@ -2792,6 +2807,7 @@ making sure that you maintain a proper JSON format.
 			{
 				"propertyName": "Unique",
 				"propertyKeyword": "compositeUniqueKey",
+				"propertyNameFull": "Composite Unique Key",
 				"propertyType": "checkbox",
 				"dependency": {
 					"key": "compositeUniqueKey",
@@ -3004,6 +3020,7 @@ making sure that you maintain a proper JSON format.
 			{
 				"propertyName": "Primary key",
 				"propertyKeyword": "compositePrimaryKey",
+				"propertyNameFull": "Composite Primary Key",
 				"propertyType": "checkbox",
 				"propertyTooltip": {
 					"disabled": [
@@ -3091,6 +3108,7 @@ making sure that you maintain a proper JSON format.
 			{
 				"propertyName": "Unique",
 				"propertyKeyword": "compositeUniqueKey",
+				"propertyNameFull": "Composite Unique Key",
 				"propertyType": "checkbox",
 				"dependency": {
 					"key": "compositeUniqueKey",
@@ -3335,6 +3353,7 @@ making sure that you maintain a proper JSON format.
 			{
 				"propertyName": "Primary key",
 				"propertyKeyword": "compositePrimaryKey",
+				"propertyNameFull": "Composite Primary Key",
 				"propertyType": "checkbox",
 				"propertyTooltip": {
 					"disabled": [
@@ -3422,6 +3441,7 @@ making sure that you maintain a proper JSON format.
 			{
 				"propertyName": "Unique",
 				"propertyKeyword": "compositeUniqueKey",
+				"propertyNameFull": "Composite Unique Key",
 				"propertyType": "checkbox",
 				"dependency": {
 					"key": "compositeUniqueKey",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-8740" title="HCK-8740" target="_blank"><img alt="Task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />HCK-8740</a>  Excel. Include 'Composite Primary Key' and 'Composite Unique Key' in export to Excel for supported engines
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Added propertyNameFull so composite PK/UK can be exported to Excel