### PR TITLE
HCK-9291: fix forward-engieering of empty TBLPROPERTIES

### DIFF
--- a/forward_engineering/ddlProvider/ddlProvider.js
+++ b/forward_engineering/ddlProvider/ddlProvider.js
@@ -11,7 +11,7 @@ const {
 	wrapInBrackets,
 } = require('../utils/general');
 const { getViewTagsStatement } = require('../helpers/unityTagsHelper');
-const { getTablePropertiesClause } = require('../helpers/tableHelper');
+const { getTablePropertiesClause, checkTablePropertiesDefined } = require('../helpers/tableHelper');
 const viewHelper = require('../helpers/viewHelper');
 
 module.exports = app => {
@@ -57,7 +57,7 @@ module.exports = app => {
 					: viewHelper.getDefaultColumnList(columns),
 				schemaBinding: '',
 				comment: viewHelper.getCommentStatement(schema.description),
-				tablePropertyStatements: tableProperties.length
+				tablePropertyStatements: checkTablePropertiesDefined(tableProperties)
 					? `TBLPROPERTIES (${getTablePropertiesClause(tableProperties)})`
 					: '',
 				query: schema.selectStatement

--- a/forward_engineering/helpers/tableHelper.js
+++ b/forward_engineering/helpers/tableHelper.js
@@ -164,7 +164,7 @@ const getCreateUsingStatement = ({
 		numBuckets && clusteredKeys,
 		`INTO ${numBuckets} BUCKETS`,
 	)(location, `LOCATION '${location}'`)(comment, `COMMENT '${encodeStringLiteral(comment)}'`)(
-		tableProperties,
+		checkTablePropertiesDefined(tableProperties),
 		`TBLPROPERTIES (${getTablePropertiesClause(tableProperties)})`,
 	)(tableOptions, `OPTIONS ${tableOptions}`)(selectStatement, `AS ${selectStatement}`)(true, ';')();
 };
@@ -199,7 +199,7 @@ const getCreateHiveStatement = ({
 	)(rowFormatStatement, `ROW FORMAT ${rowFormatStatement}`)(storedAsStatement, storedAsStatement)(
 		location,
 		`LOCATION '${location}'`,
-	)(tableProperties, `TBLPROPERTIES (${getTablePropertiesClause(tableProperties)})`)(
+	)(checkTablePropertiesDefined(tableProperties), `TBLPROPERTIES (${getTablePropertiesClause(tableProperties)})`)(
 		tableOptions,
 		`OPTIONS ${tableOptions}`,
 	)(selectStatement, `AS ${selectStatement}`)(true, ';')();
@@ -230,7 +230,7 @@ const getCreateLikeStatement = ({
 	)(true, ')')(using, `${getUsing(using)}`)(rowFormatStatement, `ROW FORMAT ${rowFormatStatement}`)(
 		storedAsStatement,
 		storedAsStatement,
-	)(tableProperties, `TBLPROPERTIES (${getTablePropertiesClause(tableProperties)})`)(
+	)(checkTablePropertiesDefined(tableProperties), `TBLPROPERTIES (${getTablePropertiesClause(tableProperties)})`)(
 		tableOptions,
 		`OPTIONS ${tableOptions}`,
 	)(location, `LOCATION '${location}'`)(true, ';')();
@@ -550,6 +550,10 @@ const getTablePropertiesClause = tableProperties => {
 	return tablePropertyStatements.join(', ');
 };
 
+const checkTablePropertiesDefined = tableProperties => {
+	return Boolean(tableProperties.length && tableProperties.some(property => property.propertyKey));
+};
+
 const hydrateTableProperties = ({ new: newItems, old: oldItems }, name) => {
 	const preparePropertiesName = properties => _.map(properties, ({ propertyKey }) => propertyKey).join(', ');
 	const { add, drop } = getDifferentItems(newItems, oldItems);
@@ -580,4 +584,5 @@ module.exports = {
 	getTableStatement,
 	getTablePropertiesClause,
 	hydrateTableProperties,
+	checkTablePropertiesDefined,
 };

--- a/forward_engineering/helpers/tableHelper.js
+++ b/forward_engineering/helpers/tableHelper.js
@@ -551,7 +551,7 @@ const getTablePropertiesClause = tableProperties => {
 };
 
 const checkTablePropertiesDefined = tableProperties => {
-	return Boolean(tableProperties.length && tableProperties.some(property => property.propertyKey));
+	return Boolean(tableProperties?.length && tableProperties?.some(property => property.propertyKey));
 };
 
 const hydrateTableProperties = ({ new: newItems, old: oldItems }, name) => {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-9291" title="HCK-9291" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-9291</a>  When there is no table properties we shouldn't forward-engieer them
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

In some cases even when `tableProperties` property was an empty array we FE'd it. I added a check to ensure that only non-empty array is FE'd. I also check that group items include `propertyKey` to be sure that anything will be FE'd 