### PR TITLE
HCK-9310: do not FE table property if the property value is not defined

### DIFF
--- a/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/modifyPropertiesHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/modifyPropertiesHelper.js
@@ -1,6 +1,6 @@
 const _ = require('lodash');
 const { DiffMap } = require('../../types/DiffMap');
-const { getTablePropertiesClause } = require('../../../helpers/tableHelper');
+const { getTablePropertiesClause, getDeleteTablePropertiesClause } = require('../../../helpers/tableHelper');
 const { AlterScriptDto } = require('../../types/AlterScriptDto');
 const { generateFullEntityName } = require('../../../utils/general');
 
@@ -54,7 +54,7 @@ const getDeleteTablePropertyScriptDto = ddlProvider => (properties, fullCollecti
 		...prop,
 		propertyValue: undefined,
 	}));
-	const dropPropertiesDdlString = getTablePropertiesClause(propertiesWithNoValues);
+	const dropPropertiesDdlString = getDeleteTablePropertiesClause(propertiesWithNoValues);
 	const ddlConfig = {
 		name: fullCollectionName,
 		properties: dropPropertiesDdlString,

--- a/forward_engineering/helpers/tableHelper.js
+++ b/forward_engineering/helpers/tableHelper.js
@@ -549,6 +549,14 @@ const getTablePropertiesClause = tableProperties => {
 	return tablePropertyStatements.join(', ');
 };
 
+const getDeleteTablePropertiesClause = tableProperties => {
+	const tablePropertyStatements = (tableProperties || [])
+		.filter(({ propertyKey }) => propertyKey?.trim?.())
+		.map(({ propertyKey }) => adjustPropertyKey(propertyKey));
+
+	return tablePropertyStatements.join(', ');
+};
+
 const checkTablePropertiesDefined = tableProperties => {
 	return Boolean(
 		tableProperties?.length &&
@@ -587,4 +595,5 @@ module.exports = {
 	getTablePropertiesClause,
 	hydrateTableProperties,
 	checkTablePropertiesDefined,
+	getDeleteTablePropertiesClause,
 };

--- a/forward_engineering/helpers/tableHelper.js
+++ b/forward_engineering/helpers/tableHelper.js
@@ -538,12 +538,9 @@ const getCorrectUsing = using => {
 const getTablePropertiesClause = tableProperties => {
 	const isText = _.overEvery([value => _.isNaN(_.toNumber(value)), value => value !== 'true' && value !== 'false']);
 	const tablePropertyStatements = (tableProperties || [])
-		.filter(({ propertyKey }) => Boolean(adjustPropertyKey(propertyKey)))
-		.map(({ propertyKey, propertyValue = undefined }) => {
+		.filter(({ propertyKey, propertyValue }) => propertyKey?.trim?.() && propertyValue?.trim?.())
+		.map(({ propertyKey, propertyValue }) => {
 			let value = propertyValue;
-			if (value === undefined) {
-				return propertyKey;
-			}
 			if (isText(value)) {
 				value = `'${adjustPropertyValue(value)}'`;
 			}
@@ -553,7 +550,10 @@ const getTablePropertiesClause = tableProperties => {
 };
 
 const checkTablePropertiesDefined = tableProperties => {
-	return Boolean(tableProperties?.length && tableProperties?.some(property => property.propertyKey));
+	return Boolean(
+		tableProperties?.length &&
+			tableProperties?.some(property => property.propertyKey?.trim?.() && property.propertyValue?.trim?.()),
+	);
 };
 
 const hydrateTableProperties = ({ new: newItems, old: oldItems }, name) => {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-9310" title="HCK-9310" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-9310</a>  Investigate whether it is possible to set a table property key without a value
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

When the table property value is not provided we shouldn't FE it