### PR TITLE
HCK-9419: remove restriction for generating script of pk keys if they are clustering keys

### DIFF
--- a/forward_engineering/helpers/keyHelper.js
+++ b/forward_engineering/helpers/keyHelper.js
@@ -25,9 +25,7 @@ const getKeyNames = (tableData, jsonSchema, definitions) => {
 	);
 
 	const keysPaths = jsonSchemaHelper.getPathsByIds(ids, [jsonSchema, ...definitions]);
-	const primaryKeysPath = jsonSchemaHelper
-		.getPrimaryKeys(jsonSchema)
-		.filter(pkPath => !keysPaths.find(path => path[path.length - 1] === pkPath[pkPath.length - 1]));
+	const primaryKeysPath = jsonSchemaHelper.getPrimaryKeys(jsonSchema);
 	const idToNameHashTable = jsonSchemaHelper.getIdToNameHashTable([jsonSchema, ...definitions]);
 	const getNameByPath = jsonSchemaHelper.getNameByPath.bind(null, idToNameHashTable);
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-9419" title="HCK-9419" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-9419</a>  1) PK constraint not in FE script
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
