### PR TITLE
HCK-9572: fix duplication of clustering key in forward-engineered script

### DIFF
--- a/forward_engineering/helpers/keyHelper.js
+++ b/forward_engineering/helpers/keyHelper.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { uniq } = require('lodash');
 const jsonSchemaHelper = require('./jsonSchemaHelper');
 
 const filterPaths = (keys, paths) => paths.filter(path => keys.find(key => path[path.length - 1] === key.keyId));
@@ -20,8 +21,8 @@ const getKeyNames = (tableData, jsonSchema, definitions) => {
 	const skewedby = tableData.skewedby || [];
 	const sortedByKey = tableData.sortedByKey || [];
 
-	const ids = [...compositeClusteringKey, ...compositePartitionKey, ...skewedby, ...sortedByKey].map(
-		key => key.keyId,
+	const ids = uniq(
+		[...compositeClusteringKey, ...compositePartitionKey, ...skewedby, ...sortedByKey].map(key => key.keyId),
 	);
 
 	const keysPaths = jsonSchemaHelper.getPathsByIds(ids, [jsonSchema, ...definitions]);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-9572" title="HCK-9572" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-9572</a>  [PROD]: Sort keys are duplicated in clustering keys for CLUSTERED BY clause
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

When the same column is used as clustering key and sort key, we duplicated the value in the array of keys, so the value appeared twice in the script.