### PR TITLE
HCK-10395: fix parsing materialized view names

### DIFF
--- a/reverse_engineering/sqlBaseToCollectionsVisitor.js
+++ b/reverse_engineering/sqlBaseToCollectionsVisitor.js
@@ -91,13 +91,14 @@ class Visitor extends SqlBaseVisitor {
 		const colList = identifierCommentListCtx
 			? this.visit(identifierCommentListCtx)
 			: colTypeCtx && this.getText(colTypeCtx);
-
+		const identifiers = identifier.split('.');
+		const dbName = identifiers.length === 2 ? identifiers[0] : identifiers[1];
 		return {
 			materialized: true,
 			orReplace: this.visitFlagValue(ctx, 'REPLACE'),
 			ifNotExists: this.visitFlagValue(ctx, 'EXISTS'),
-			identifier: identifier.split('.')[1],
-			dbName: identifier.split('.')[0] || '',
+			identifier: _.last(identifiers),
+			dbName: dbName || '',
 			colList: colList,
 			tableProperties: tableClauses.tableProperties,
 			selectStatement: this.visitIfExists(ctx, 'query'),


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-10395" title="HCK-10395" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-10395</a>  [DeltaLake][RE] Matview reversed with unexpected Technical name equal to Schema name
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

Unlike regular views, the identifier of materialized views includes the cluster name `clusterName.schemaName.viewName`