### PR TITLE
HCK-11275: prevent crash of the process when file does not exist; improve progress message

### DIFF
--- a/reverse_engineering/helpers/fetchRequestHelper.js
+++ b/reverse_engineering/helpers/fetchRequestHelper.js
@@ -116,8 +116,12 @@ const logProgressOfSendingSampleBatches = logger => (lineIndex, amountOfLines) =
 	if (!shouldLogStep(lineIndex)) {
 		return;
 	}
+
 	const progress = Number(lineIndex / amountOfLines);
-	const message = `Inserted ${lineIndex} lines out of ${amountOfLines}, progress ${progress.toFixed(2)}%`;
+	const message =
+		lineIndex === 0
+			? `Start inserting data`
+			: `Inserted ${lineIndex} lines out of ${amountOfLines}, progress ${progress.toFixed(2)}%`;
 	logger.log('info', { message }, 'SEND_SAMPLE_BATCHES');
 	logger.progress({ message });
 };

--- a/reverse_engineering/helpers/fileHelper.js
+++ b/reverse_engineering/helpers/fileHelper.js
@@ -6,6 +6,10 @@ const readline = require('readline');
  * @return {Promise<number>}
  * */
 const getCountOfLines = filePath => {
+	if (!fs.existsSync(filePath)) {
+		throw new Error(`File "${filePath}" does not exist`);
+	}
+
 	const fileStream = fs.createReadStream(filePath);
 	const rl = readline.createInterface({
 		input: fileStream,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-11275" title="HCK-11275" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-11275</a>  Imporve progress message and preven process crash when the file doesn't exist
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

It seems like the `readline.createInterface` crashes the process if file does not exist. To prevent this I throw my own error so the error handling works correctly and we log this error.