### PR TITLE
HCK-11483: fix dependency that allows timestamp_ntz in runtime 13+

### DIFF
--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -1505,18 +1505,46 @@ making sure that you maintain a proper JSON format.
 				"options": ["", "timestamp_ntz"],
 				"data": "options",
 				"valueType": "string",
-				"dependency": [
-					{
-						"level": "model",
-						"key": "dbVersion",
-						"value": "Runtime 13"
-					},
-					{
-						"level": "model",
-						"key": "dbVersion",
-						"value": "Runtime 14"
-					}
-				]
+				"dependency": {
+					"type": "not",
+					"values": [
+						{
+							"level": "model",
+							"key": "dbVersion",
+							"value": "Runtime 6"
+						},
+						{
+							"level": "model",
+							"key": "dbVersion",
+							"value": "Runtime 7"
+						},
+						{
+							"level": "model",
+							"key": "dbVersion",
+							"value": "Runtime 8"
+						},
+						{
+							"level": "model",
+							"key": "dbVersion",
+							"value": "Runtime 9"
+						},
+						{
+							"level": "model",
+							"key": "dbVersion",
+							"value": "Runtime 10"
+						},
+						{
+							"level": "model",
+							"key": "dbVersion",
+							"value": "Runtime 11"
+						},
+						{
+							"level": "model",
+							"key": "dbVersion",
+							"value": "Runtime 12"
+						}
+					]
+				}
 			},
 			"pattern",
 			"enum",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-11483" title="HCK-11483" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-11483</a>  Fix availability of TIMESTAMP_NTZ in Runtime 13+
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
