### PR TITLE
HCK-11799: improve unity tags validation regular expression to allow spaces inside the name and underscore usage

### DIFF
--- a/properties_pane/container_level/containerLevelConfig.json
+++ b/properties_pane/container_level/containerLevelConfig.json
@@ -168,7 +168,7 @@ making sure that you maintain a proper JSON format.
 						"propertyType": "text",
 						"shouldValidate": true,
 						"validation": {
-							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?[a-zA-Z\\d]{1,255}$"
+							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?\\S[a-zA-Z\\d\\s_]{1,253}\\S$"
 						}
 					},
 					{
@@ -243,7 +243,7 @@ making sure that you maintain a proper JSON format.
 						"propertyTooltip": "The key of the tag must be between 1 and 255 UTF-8 characters inclusive, special characters cannot be used in tag names",
 						"propertyType": "text",
 						"validation": {
-							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?[a-zA-Z\\d]{1,255}$"
+							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?\\S[a-zA-Z\\d\\s_]{1,253}\\S$"
 						}
 					},
 					{

--- a/properties_pane/entity_level/entityLevelConfig.json
+++ b/properties_pane/entity_level/entityLevelConfig.json
@@ -496,7 +496,7 @@ making sure that you maintain a proper JSON format.
 						"propertyTooltip": "The key of the tag must be between 1 and 255 UTF-8 characters inclusive, special characters cannot be used in tag names",
 						"propertyType": "text",
 						"validation": {
-							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?[a-zA-Z\\d]{1,255}$"
+							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?\\S[a-zA-Z\\d\\s_]{1,253}\\S$"
 						}
 					},
 					{

--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -513,7 +513,7 @@ making sure that you maintain a proper JSON format.
 						"propertyTooltip": "The key of the tag must be between 1 and 255 UTF-8 characters inclusive, special characters cannot be used in tag names",
 						"propertyType": "text",
 						"validation": {
-							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?[a-zA-Z\\d]{1,255}$"
+							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?\\S[a-zA-Z\\d\\s_]{1,253}\\S$"
 						}
 					},
 					{
@@ -946,7 +946,7 @@ making sure that you maintain a proper JSON format.
 						"propertyTooltip": "The key of the tag must be between 1 and 255 UTF-8 characters inclusive, special characters cannot be used in tag names",
 						"propertyType": "text",
 						"validation": {
-							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?[a-zA-Z\\d]{1,255}$"
+							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?\\S[a-zA-Z\\d\\s_]{1,253}\\S$"
 						}
 					},
 					{
@@ -1104,7 +1104,7 @@ making sure that you maintain a proper JSON format.
 						"propertyTooltip": "The key of the tag must be between 1 and 255 UTF-8 characters inclusive, special characters cannot be used in tag names",
 						"propertyType": "text",
 						"validation": {
-							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?[a-zA-Z\\d]{1,255}$"
+							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?\\S[a-zA-Z\\d\\s_]{1,253}\\S$"
 						}
 					},
 					{
@@ -1428,7 +1428,7 @@ making sure that you maintain a proper JSON format.
 						"propertyTooltip": "The key of the tag must be between 1 and 255 UTF-8 characters inclusive, special characters cannot be used in tag names",
 						"propertyType": "text",
 						"validation": {
-							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?[a-zA-Z\\d]{1,255}$"
+							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?\\S[a-zA-Z\\d\\s_]{1,253}\\S$"
 						}
 					},
 					{
@@ -1807,7 +1807,7 @@ making sure that you maintain a proper JSON format.
 						"propertyTooltip": "The key of the tag must be between 1 and 255 UTF-8 characters inclusive, special characters cannot be used in tag names",
 						"propertyType": "text",
 						"validation": {
-							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?[a-zA-Z\\d]{1,255}$"
+							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?\\S[a-zA-Z\\d\\s_]{1,253}\\S$"
 						}
 					},
 					{
@@ -2137,7 +2137,7 @@ making sure that you maintain a proper JSON format.
 						"propertyTooltip": "The key of the tag must be between 1 and 255 UTF-8 characters inclusive, special characters cannot be used in tag names",
 						"propertyType": "text",
 						"validation": {
-							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?[a-zA-Z\\d]{1,255}$"
+							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?\\S[a-zA-Z\\d\\s_]{1,253}\\S$"
 						}
 					},
 					{
@@ -2466,7 +2466,7 @@ making sure that you maintain a proper JSON format.
 						"propertyTooltip": "The key of the tag must be between 1 and 255 UTF-8 characters inclusive, special characters cannot be used in tag names",
 						"propertyType": "text",
 						"validation": {
-							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?[a-zA-Z\\d]{1,255}$"
+							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?\\S[a-zA-Z\\d\\s_]{1,253}\\S$"
 						}
 					},
 					{
@@ -2811,7 +2811,7 @@ making sure that you maintain a proper JSON format.
 						"propertyTooltip": "The key of the tag must be between 1 and 255 UTF-8 characters inclusive, special characters cannot be used in tag names",
 						"propertyType": "text",
 						"validation": {
-							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?[a-zA-Z\\d]{1,255}$"
+							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?\\S[a-zA-Z\\d\\s_]{1,253}\\S$"
 						}
 					},
 					{
@@ -3181,7 +3181,7 @@ making sure that you maintain a proper JSON format.
 						"propertyTooltip": "The key of the tag must be between 1 and 255 UTF-8 characters inclusive, special characters cannot be used in tag names",
 						"propertyType": "text",
 						"validation": {
-							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?[a-zA-Z\\d]{1,255}$"
+							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?\\S[a-zA-Z\\d\\s_]{1,253}\\S$"
 						}
 					},
 					{
@@ -3507,7 +3507,7 @@ making sure that you maintain a proper JSON format.
 						"propertyTooltip": "The key of the tag must be between 1 and 255 UTF-8 characters inclusive, special characters cannot be used in tag names",
 						"propertyType": "text",
 						"validation": {
-							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?[a-zA-Z\\d]{1,255}$"
+							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?\\S[a-zA-Z\\d\\s_]{1,253}\\S$"
 						}
 					},
 					{
@@ -3866,7 +3866,7 @@ making sure that you maintain a proper JSON format.
 						"propertyTooltip": "The key of the tag must be between 1 and 255 UTF-8 characters inclusive, special characters cannot be used in tag names",
 						"propertyType": "text",
 						"validation": {
-							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?[a-zA-Z\\d]{1,255}$"
+							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?\\S[a-zA-Z\\d\\s_]{1,253}\\S$"
 						}
 					},
 					{

--- a/properties_pane/view_level/viewLevelConfig.json
+++ b/properties_pane/view_level/viewLevelConfig.json
@@ -275,7 +275,7 @@ making sure that you maintain a proper JSON format.
 						"propertyTooltip": "The key of the tag must be between 1 and 255 UTF-8 characters inclusive, special characters cannot be used in tag names",
 						"propertyType": "text",
 						"validation": {
-							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?[a-zA-Z\\d]{1,255}$"
+							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?\\S[a-zA-Z\\d\\s_]{1,253}\\S$"
 						}
 					},
 					{


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-11799" title="HCK-11799" target="_blank"><img alt="Task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />HCK-11799</a>  [Nike][Delta Lake] Tag key error badge should follow specs
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Improved unity tags validation regular expression to allow spaces inside the name and underscore usage

## Technical details

Allowed space to be not the last and not the first character in a tag name. Added underscore to characters white list