### PR TITLE
HCK-11912: fix the order of alter statements

### DIFF
--- a/forward_engineering/alterScript/alterScriptFromDeltaHelper.js
+++ b/forward_engineering/alterScript/alterScriptFromDeltaHelper.js
@@ -234,10 +234,10 @@ const getAlterCollectionsScriptDtos = ({ schema, definitions, provider, data, ap
 		...addedCollectionsScriptDtos,
 		...modifiedCollectionsScriptDtos,
 		...modifiedCollectionCommentsScriptDtos,
-		...modifiedCollectionPrimaryKeysScriptDtos,
 		...deletedColumnsScriptDtosWithNoDuplicates,
 		...addedColumnsScriptDtosWithNoDuplicates,
 		...modifiedColumnsScriptDtosWithNoDuplicates,
+		...modifiedCollectionPrimaryKeysScriptDtos,
 	].filter(Boolean);
 };
 

--- a/forward_engineering/alterScript/alterScriptFromDeltaHelper.js
+++ b/forward_engineering/alterScript/alterScriptFromDeltaHelper.js
@@ -198,8 +198,6 @@ const getAlterCollectionsScriptDtos = ({ schema, definitions, provider, data, ap
 		getModifyCollectionCommentsScripts(provider)({ collection: item, dbVersion }),
 	);
 
-	const modifiedCollectionPrimaryKeysScriptDtos = getModifiedCollectionPrimaryKeysScriptDtos();
-
 	const addedColumnsItems = getItems(schema, 'entities', 'added').filter(item => !item?.compMod?.created);
 	const addedColumnsScriptDtos = getColumnScripts(
 		addedColumnsItems,
@@ -234,6 +232,7 @@ const getAlterCollectionsScriptDtos = ({ schema, definitions, provider, data, ap
 		alterScriptDtos: modifiedColumnsScriptDtos,
 		existingAlterStatements: existingAlterStatementsWithDeletedColumns,
 	});
+	const modifiedCollectionPrimaryKeysScriptDtos = getModifiedCollectionPrimaryKeysScriptDtos();
 
 	return [
 		...deletedCollectionsScriptDtos,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-11912" title="HCK-11912" target="_blank"><img alt="Task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />HCK-11912</a>  [rc remark] Script generation: put NOT NULL alter statements before PK
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
