### PR TITLE
HCK-11947: forbid invalid name characters in the beginning and in the end of a unity tag name

### DIFF
--- a/properties_pane/container_level/containerLevelConfig.json
+++ b/properties_pane/container_level/containerLevelConfig.json
@@ -168,7 +168,7 @@ making sure that you maintain a proper JSON format.
 						"propertyType": "text",
 						"shouldValidate": true,
 						"validation": {
-							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?\\S[^\\.,\\-=\\/:]{1,253}\\S$"
+							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?[^\\.,\\-=/:\\s][^\\.,\\-=/:]{1,253}[^\\.,\\-=/:\\s]$"
 						}
 					},
 					{
@@ -243,7 +243,7 @@ making sure that you maintain a proper JSON format.
 						"propertyTooltip": "The key of the tag must be between 1 and 255 UTF-8 characters inclusive, special characters cannot be used in tag names",
 						"propertyType": "text",
 						"validation": {
-							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?\\S[^\\.,\\-=\\/:]{1,253}\\S$"
+							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?[^\\.,\\-=/:\\s][^\\.,\\-=/:]{1,253}[^\\.,\\-=/:\\s]$"
 						}
 					},
 					{

--- a/properties_pane/entity_level/entityLevelConfig.json
+++ b/properties_pane/entity_level/entityLevelConfig.json
@@ -496,7 +496,7 @@ making sure that you maintain a proper JSON format.
 						"propertyTooltip": "The key of the tag must be between 1 and 255 UTF-8 characters inclusive, special characters cannot be used in tag names",
 						"propertyType": "text",
 						"validation": {
-							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?\\S[^\\.,\\-=\\/:]{1,253}\\S$"
+							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?[^\\.,\\-=/:\\s][^\\.,\\-=/:]{1,253}[^\\.,\\-=/:\\s]$"
 						}
 					},
 					{

--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -513,7 +513,7 @@ making sure that you maintain a proper JSON format.
 						"propertyTooltip": "The key of the tag must be between 1 and 255 UTF-8 characters inclusive, special characters cannot be used in tag names",
 						"propertyType": "text",
 						"validation": {
-							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?\\S[^\\.,\\-=\\/:]{1,253}\\S$"
+							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?[^\\.,\\-=/:\\s][^\\.,\\-=/:]{1,253}[^\\.,\\-=/:\\s]$"
 						}
 					},
 					{
@@ -946,7 +946,7 @@ making sure that you maintain a proper JSON format.
 						"propertyTooltip": "The key of the tag must be between 1 and 255 UTF-8 characters inclusive, special characters cannot be used in tag names",
 						"propertyType": "text",
 						"validation": {
-							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?\\S[^\\.,\\-=\\/:]{1,253}\\S$"
+							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?[^\\.,\\-=/:\\s][^\\.,\\-=/:]{1,253}[^\\.,\\-=/:\\s]$"
 						}
 					},
 					{
@@ -1104,7 +1104,7 @@ making sure that you maintain a proper JSON format.
 						"propertyTooltip": "The key of the tag must be between 1 and 255 UTF-8 characters inclusive, special characters cannot be used in tag names",
 						"propertyType": "text",
 						"validation": {
-							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?\\S[^\\.,\\-=\\/:]{1,253}\\S$"
+							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?[^\\.,\\-=/:\\s][^\\.,\\-=/:]{1,253}[^\\.,\\-=/:\\s]$"
 						}
 					},
 					{
@@ -1428,7 +1428,7 @@ making sure that you maintain a proper JSON format.
 						"propertyTooltip": "The key of the tag must be between 1 and 255 UTF-8 characters inclusive, special characters cannot be used in tag names",
 						"propertyType": "text",
 						"validation": {
-							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?\\S[^\\.,\\-=\\/:]{1,253}\\S$"
+							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?[^\\.,\\-=/:\\s][^\\.,\\-=/:]{1,253}[^\\.,\\-=/:\\s]$"
 						}
 					},
 					{
@@ -1807,7 +1807,7 @@ making sure that you maintain a proper JSON format.
 						"propertyTooltip": "The key of the tag must be between 1 and 255 UTF-8 characters inclusive, special characters cannot be used in tag names",
 						"propertyType": "text",
 						"validation": {
-							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?\\S[^\\.,\\-=\\/:]{1,253}\\S$"
+							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?[^\\.,\\-=/:\\s][^\\.,\\-=/:]{1,253}[^\\.,\\-=/:\\s]$"
 						}
 					},
 					{
@@ -2137,7 +2137,7 @@ making sure that you maintain a proper JSON format.
 						"propertyTooltip": "The key of the tag must be between 1 and 255 UTF-8 characters inclusive, special characters cannot be used in tag names",
 						"propertyType": "text",
 						"validation": {
-							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?\\S[^\\.,\\-=\\/:]{1,253}\\S$"
+							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?[^\\.,\\-=/:\\s][^\\.,\\-=/:]{1,253}[^\\.,\\-=/:\\s]$"
 						}
 					},
 					{
@@ -2466,7 +2466,7 @@ making sure that you maintain a proper JSON format.
 						"propertyTooltip": "The key of the tag must be between 1 and 255 UTF-8 characters inclusive, special characters cannot be used in tag names",
 						"propertyType": "text",
 						"validation": {
-							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?\\S[^\\.,\\-=\\/:]{1,253}\\S$"
+							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?[^\\.,\\-=/:\\s][^\\.,\\-=/:]{1,253}[^\\.,\\-=/:\\s]$"
 						}
 					},
 					{
@@ -2811,7 +2811,7 @@ making sure that you maintain a proper JSON format.
 						"propertyTooltip": "The key of the tag must be between 1 and 255 UTF-8 characters inclusive, special characters cannot be used in tag names",
 						"propertyType": "text",
 						"validation": {
-							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?\\S[^\\.,\\-=\\/:]{1,253}\\S$"
+							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?[^\\.,\\-=/:\\s][^\\.,\\-=/:]{1,253}[^\\.,\\-=/:\\s]$"
 						}
 					},
 					{
@@ -3181,7 +3181,7 @@ making sure that you maintain a proper JSON format.
 						"propertyTooltip": "The key of the tag must be between 1 and 255 UTF-8 characters inclusive, special characters cannot be used in tag names",
 						"propertyType": "text",
 						"validation": {
-							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?\\S[^\\.,\\-=\\/:]{1,253}\\S$"
+							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?[^\\.,\\-=/:\\s][^\\.,\\-=/:]{1,253}[^\\.,\\-=/:\\s]$"
 						}
 					},
 					{
@@ -3507,7 +3507,7 @@ making sure that you maintain a proper JSON format.
 						"propertyTooltip": "The key of the tag must be between 1 and 255 UTF-8 characters inclusive, special characters cannot be used in tag names",
 						"propertyType": "text",
 						"validation": {
-							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?\\S[^\\.,\\-=\\/:]{1,253}\\S$"
+							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?[^\\.,\\-=/:\\s][^\\.,\\-=/:]{1,253}[^\\.,\\-=/:\\s]$"
 						}
 					},
 					{
@@ -3866,7 +3866,7 @@ making sure that you maintain a proper JSON format.
 						"propertyTooltip": "The key of the tag must be between 1 and 255 UTF-8 characters inclusive, special characters cannot be used in tag names",
 						"propertyType": "text",
 						"validation": {
-							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?\\S[^\\.,\\-=\\/:]{1,253}\\S$"
+							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?[^\\.,\\-=/:\\s][^\\.,\\-=/:]{1,253}[^\\.,\\-=/:\\s]$"
 						}
 					},
 					{

--- a/properties_pane/view_level/viewLevelConfig.json
+++ b/properties_pane/view_level/viewLevelConfig.json
@@ -275,7 +275,7 @@ making sure that you maintain a proper JSON format.
 						"propertyTooltip": "The key of the tag must be between 1 and 255 UTF-8 characters inclusive, special characters cannot be used in tag names",
 						"propertyType": "text",
 						"validation": {
-							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?\\S[^\\.,\\-=\\/:]{1,253}\\S$"
+							"regex": "^(?=.*?\\d)?(?=.*?[a-zA-Z])?[^\\.,\\-=/:\\s][^\\.,\\-=/:]{1,253}[^\\.,\\-=/:\\s]$"
 						}
 					},
 					{


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-11947" title="HCK-11947" target="_blank"><img alt="Bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-11947</a>  [Delta Lake] Unsupported . , - = / : characters still incorrectly can be used in the begin and end of words
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Enchanced validation regex to forbid invalid name characters in the beginning and in the end of a unity tag name