### PR TITLE
HCK-12004: fix getting schema name for alter comment statement

### DIFF
--- a/forward_engineering/alterScript/alterScriptHelpers/containerHelpers/commentsHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/containerHelpers/commentsHelper.js
@@ -1,5 +1,5 @@
 const { EntitiesThatSupportComments } = require('../../../enums/entityType');
-const { replaceSpaceWithUnderscore, wrapInSingleQuotes } = require('../../../utils/general');
+const { replaceSpaceWithUnderscore, wrapInSingleQuotes, prepareName } = require('../../../utils/general');
 const { AlterScriptDto } = require('../../types/AlterScriptDto');
 
 /**
@@ -18,9 +18,10 @@ const extractDescription = container => {
 const getUpsertCommentsScriptDto = ddlProvider => container => {
 	const description = extractDescription(container);
 	if (description.new && description.new !== description.old) {
+		const schemaName = prepareName(container.role.code || container.role.name);
 		const script = ddlProvider.updateComment({
 			entityType: EntitiesThatSupportComments.SCHEMA,
-			entityName: replaceSpaceWithUnderscore(container.role.name),
+			entityName: replaceSpaceWithUnderscore(schemaName),
 			comment: wrapInSingleQuotes(description.new),
 		});
 		return {
@@ -41,9 +42,10 @@ const getUpsertCommentsScriptDto = ddlProvider => container => {
 const getDropCommentsScriptDto = ddlProvider => container => {
 	const description = extractDescription(container);
 	if (description.old && !description.new) {
+		const schemaName = prepareName(container.role.code || container.role.name);
 		const script = ddlProvider.dropComment({
 			entityType: EntitiesThatSupportComments.SCHEMA,
-			entityName: replaceSpaceWithUnderscore(container.role.name),
+			entityName: replaceSpaceWithUnderscore(schemaName),
 		});
 		return {
 			scripts: [


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-12004" title="HCK-12004" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-12004</a>  [Script generation options][Delta Lake] Business name instead of TechName is using for ALTER Schema COMMENT 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

Added use of technical name when generating a statement
