### PR TITLE
HCK-12040: Do not change relationship name

### DIFF
--- a/forward_engineering/alterScript/alterScriptFromDeltaHelper.js
+++ b/forward_engineering/alterScript/alterScriptFromDeltaHelper.js
@@ -342,7 +342,6 @@ const getAlterScriptDtos = (schema, definitions, data, app) => {
 			schema,
 			ddlProvider: provider,
 			initialSchemaName: currentSchemaName,
-			options: data.options,
 		});
 	}
 

--- a/forward_engineering/alterScript/alterScriptHelpers/alterRelationshipsHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/alterRelationshipsHelper.js
@@ -37,19 +37,16 @@ const getFullChildTableName = relationship => {
 /**
  * @return {(relationship: Object) => string}
  * */
-const getAddSingleForeignKeyScript = (ddlProvider, options) => relationship => {
+const getAddSingleForeignKeyScript = ddlProvider => relationship => {
 	const compMod = relationship.role.compMod;
 	const parentTableName = getFullParentTableName(relationship);
 	const childTableName = getFullChildTableName(relationship);
 
 	const relationshipName = compMod.name?.new || getRelationshipName(relationship) || '';
-	const fkName = options?.isCreate
-		? replaceSpaceWithUnderscore(replaceDotWithUnderscore(prepareName(relationshipName)))
-		: prepareName(relationshipName);
 
 	const addFkConstraintDto = {
 		childTableName,
-		fkConstraintName: fkName,
+		fkConstraintName: prepareName(relationshipName),
 		childColumns: compMod.child.collection.fkFields.map(field => prepareName(field.name)),
 		parentTableName,
 		parentColumns: compMod.parent.collection.fkFields.map(field => prepareName(field.name)),
@@ -80,8 +77,8 @@ const canRelationshipBeAdded = relationship => {
 /**
  * @return {(addedRelationships: Array<Object>) => Array<AlterScriptDto>}
  * */
-const getAddForeignKeyScript = (ddlProvider, options) => relationship => {
-	const script = getAddSingleForeignKeyScript(ddlProvider, options)(relationship);
+const getAddForeignKeyScript = ddlProvider => relationship => {
+	const script = getAddSingleForeignKeyScript(ddlProvider)(relationship);
 
 	return {
 		isActivated: Boolean(relationship.role?.compMod?.isActivated?.new),
@@ -162,7 +159,7 @@ const getModifyForeignKeyScript = ddlProvider => relationship => {
 	};
 };
 
-const getAlterRelationshipsScriptDtos = ({ schema, ddlProvider, initialSchemaName, options }) => {
+const getAlterRelationshipsScriptDtos = ({ schema, ddlProvider, initialSchemaName }) => {
 	let currentSchemaName = initialSchemaName;
 
 	const generateAddFkScriptDtos = (addedRelationships, getScript) => {
@@ -177,7 +174,7 @@ const getAlterRelationshipsScriptDtos = ({ schema, ddlProvider, initialSchemaNam
 
 	const getRelationshipsScriptsWithUseSchema = (relationships, processRelationships, getScript) => {
 		return processRelationships(relationships, relationship => {
-			const scriptDto = getScript(ddlProvider, options)(relationship);
+			const scriptDto = getScript(ddlProvider)(relationship);
 			const scriptIsNotEmpty = scriptDto.scripts.some(scriptDto => Boolean(scriptDto.script));
 
 			if (!scriptIsNotEmpty) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-12040" title="HCK-12040" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-12040</a>  Change the logic to not override relationship names
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Previous changes were temporary merged to simulate older approach of renaming the relationship names on creating. After the changes to studio, we can revert this changes.