### PR TITLE
HCK-12045: fix getting name for alter pk constraint

### DIFF
--- a/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/primaryKeyHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/primaryKeyHelper.js
@@ -40,6 +40,14 @@ const didCompositePkChange = collection => {
 };
 
 /**
+ * @param {object} collection
+ * @returns {string}
+ */
+const getDefaultPkConstraintName = collection => {
+	return getEntityNameFromCollection(collection) + '_pk';
+};
+
+/**
  * @return {({collection, dbVersion }: {collection: Object, dbVersion: string }) => Array<AlterScriptDto>}
  * */
 const getAddCompositePkScripts =
@@ -50,7 +58,6 @@ const getAddCompositePkScripts =
 			return [];
 		}
 		const fullTableName = generateFullEntityName({ entity: collection, dbVersion });
-		const constraintName = getEntityNameFromCollection(collection) + '_pk';
 		const pkDto = collection?.role?.compMod?.primaryKey || {};
 		const newPrimaryKeys = pkDto.new || [];
 
@@ -59,6 +66,8 @@ const getAddCompositePkScripts =
 				const compositePrimaryKey = newPk.compositePrimaryKey || [];
 				const guidsOfColumnsInPk = compositePrimaryKey.map(compositePkEntry => compositePkEntry.keyId);
 				const columnNamesForDDL = getPropertiesNamesByGUIDs(collection, guidsOfColumnsInPk);
+				const constraintName = newPk.constraintName || getDefaultPkConstraintName(collection);
+
 				if (!columnNamesForDDL.length) {
 					return undefined;
 				}
@@ -119,7 +128,6 @@ const getAddPkScripts =
 	ddlProvider =>
 	({ collection, dbVersion }) => {
 		const fullTableName = generateFullEntityName({ entity: collection, dbVersion });
-		const constraintName = getEntityNameFromCollection(collection) + '_pk';
 
 		return _.toPairs(collection.properties)
 			.filter(([name, jsonSchema]) => {
@@ -131,6 +139,9 @@ const getAddPkScripts =
 			.map(([name, jsonSchema]) => {
 				const nameForDDl = prepareName(name);
 				const columnNamesForDDL = [nameForDDl];
+				const constraintName =
+					jsonSchema.primaryKeyOptions?.constraintName || getDefaultPkConstraintName(collection);
+
 				return ddlProvider.addPkConstraint(fullTableName, constraintName, columnNamesForDDL);
 			})
 			.map(scriptLine => ({


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-12045" title="HCK-12045" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-12045</a>  [DeltaLake][FE] Primary Key constraint options completely ignored if 'In separate statement' for PK is selected
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

The defined constraint name was always ignored in the alter statement