### PR TITLE
HCK-12405: exponential retry for queued API command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
 	"name": "DeltaLake",
-	"version": "0.2.32",
+	"version": "0.2.35",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "DeltaLake",
-			"version": "0.2.32",
+			"version": "0.2.35",
 			"hasInstallScript": true,
 			"dependencies": {
 				"@sqltools/formatter": "1.2.5",
 				"abort-controller": "3.0.0",
 				"antlr4": "4.9.2",
 				"async": "3.2.6",
+				"exponential-backoff": "3.1.2",
 				"ip": "2.0.1",
 				"lodash": "4.17.21",
 				"node-fetch": "2.6.7"
@@ -2097,6 +2098,12 @@
 			"funding": {
 				"url": "https://github.com/sindresorhus/execa?sponsor=1"
 			}
+		},
+		"node_modules/exponential-backoff": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.2.tgz",
+			"integrity": "sha512-8QxYTVXUkuy7fIIoitQkPwGonB8F3Zj8eEO8Sqg9Zv/bkI7RJAzowee4gr81Hak/dUTpA2Z7VfQgoijjPNlUZA==",
+			"license": "Apache-2.0"
 		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
         "abort-controller": "3.0.0",
         "antlr4": "4.9.2",
         "async": "3.2.6",
+        "exponential-backoff": "3.1.2",
         "ip": "2.0.1",
         "lodash": "4.17.21",
         "node-fetch": "2.6.7"

--- a/reverse_engineering/api.js
+++ b/reverse_engineering/api.js
@@ -86,7 +86,10 @@ module.exports = {
 			} else if (connectionInfo.catalogName) {
 				catalogNames = [connectionInfo.catalogName];
 			} else {
-				catalogNames = await fetchRequestHelper.fetchClusterCatalogNames(connectionData);
+				catalogNames = await fetchRequestHelper.fetchClusterCatalogNames({
+					connectionInfo: connectionData,
+					logger,
+				});
 			}
 
 			logger.log('info', catalogNames, 'Catalog names list');
@@ -389,7 +392,7 @@ module.exports = {
 						if (fieldInference.active === 'field') {
 							documentTemplate = getTemplateDocByJsonSchema(jsonSchema);
 						}
-					} catch (e) {
+					} catch {
 						logger.log('info', data, `Error parsing ddl statement: \n${ddl}\n`, data.hiddenKeys);
 						return createViewPackage({ name });
 					}

--- a/reverse_engineering/helpers/databricksHelper.js
+++ b/reverse_engineering/helpers/databricksHelper.js
@@ -10,7 +10,7 @@ const getEntityCreateStatement = (connectionInfo, dbName, entityName, logger) =>
 };
 
 const getFirstDatabaseCollectionName = async (connectionInfo, sparkVersion, logger) => {
-	const databasesNames = await fetchRequestHelper.fetchClusterDatabasesNames(connectionInfo);
+	const databasesNames = await fetchRequestHelper.fetchClusterDatabasesNames({ connectionInfo, logger });
 	logger.log('info', databasesNames, `Schema list`);
 	if (_.isEmpty(databasesNames)) {
 		return;
@@ -18,7 +18,11 @@ const getFirstDatabaseCollectionName = async (connectionInfo, sparkVersion, logg
 
 	const firstDatabaseName = _.first(databasesNames);
 
-	const tableNames = await fetchRequestHelper.fetchClusterTablesNames(firstDatabaseName, connectionInfo);
+	const tableNames = await fetchRequestHelper.fetchClusterTablesNames({
+		dbName: firstDatabaseName,
+		connectionInfo,
+		logger,
+	});
 	logger.log('info', tableNames, `Tables list in ${firstDatabaseName} schema`);
 	const viewNames = await getDatabaseViewNames(firstDatabaseName, connectionInfo, sparkVersion, logger);
 	logger.log('info', viewNames, `Views list in ${firstDatabaseName} schema`);
@@ -26,7 +30,11 @@ const getFirstDatabaseCollectionName = async (connectionInfo, sparkVersion, logg
 
 const fetchViewNamesFallback = async (dbName, connectionInfo, logger) => {
 	try {
-		const viewNamesResponse = await fetchRequestHelper.fetchDatabaseViewsNamesViaPython(dbName, connectionInfo);
+		const viewNamesResponse = await fetchRequestHelper.fetchDatabaseViewsNamesViaPython({
+			dbName,
+			connectionInfo,
+			logger,
+		});
 		const viewNames = JSON.parse(viewNamesResponse);
 		return viewNames.map(name => [dbName, name]);
 	} catch (error) {
@@ -37,7 +45,7 @@ const fetchViewNamesFallback = async (dbName, connectionInfo, logger) => {
 
 const fetchViewNames = (dbName, connectionInfo, logger) => {
 	try {
-		return fetchRequestHelper.fetchDatabaseViewsNames(dbName, connectionInfo);
+		return fetchRequestHelper.fetchDatabaseViewsNames({ dbName, connectionInfo, logger });
 	} catch (error) {
 		logger.log(
 			'warning',
@@ -64,16 +72,16 @@ const getDatabaseViewNames = async (dbName, connectionInfo, sparkVersion, logger
 
 const getDatabaseCollectionNames = async (connectionInfo, sparkVersion, logger) => {
 	if (isSupportUnityCatalog(sparkVersion)) {
-		await fetchRequestHelper.useCatalog(connectionInfo);
+		await fetchRequestHelper.useCatalog({ connectionInfo, logger });
 	}
 
 	const databasesNames = connectionInfo.databaseName
 		? [connectionInfo.databaseName]
-		: await fetchRequestHelper.fetchClusterDatabasesNames(connectionInfo);
+		: await fetchRequestHelper.fetchClusterDatabasesNames({ connectionInfo, logger });
 
 	return await async.mapLimit(databasesNames, 30, async dbName => {
 		const { views, viewNames } = await getDatabaseViewNames(dbName, connectionInfo, sparkVersion, logger);
-		const tablesResult = await fetchRequestHelper.fetchClusterTablesNames(dbName, connectionInfo);
+		const tablesResult = await fetchRequestHelper.fetchClusterTablesNames({ dbName, connectionInfo, logger });
 		const tables = tablesResult.reduce((databaseTables, [dbName, tableName]) => {
 			if (viewNames.includes(tableName)) {
 				return databaseTables;

--- a/reverse_engineering/helpers/fetchRequestHelper.js
+++ b/reverse_engineering/helpers/fetchRequestHelper.js
@@ -1,16 +1,19 @@
-'use strict';
-
 const async = require('async');
 const _ = require('lodash');
 const nodeFetch = require('node-fetch');
 const AbortController = require('abort-controller');
+const { backOff } = require('exponential-backoff');
+
 const { getClusterData, getViewNamesCommand } = require('./pythonScriptGeneratorHelper');
 const { prepareNamesForInsertionIntoScalaCode, removeParentheses } = require('./utils');
 const { generateSamplesScript } = require('../../forward_engineering/sampleGeneration/sampleGenerationService');
 const { batchProcessFile } = require('./fileHelper');
+const { COMMAND_EXECUTION_STATUS, REQUEST_TIMEOUT_MESSAGE } = require('../../shared/constants');
 
 const JSON_OBJECTS_DELIMITER = '}, {';
 const BATCH_SIZE = 5000;
+
+const COMMAND_EXECUTION_MAX_DELAY = 3000;
 
 let activeContexts = {};
 
@@ -45,9 +48,7 @@ const fetch = (query, options, attempts = 10) => {
 					}, 1000);
 				});
 			} else if (error.type === 'aborted') {
-				throw new Error(
-					'Request timeout exceeded, please try again or increase query request timeout in Tools > Options > Reverse-Engineering',
-				);
+				throw new Error(REQUEST_TIMEOUT_MESSAGE);
 			} else {
 				throw error;
 			}
@@ -87,15 +88,18 @@ const destroyActiveContext = () => {
 };
 
 /**
- * @return {(
- *     connectionInfo: Object,
- *     samples: Array<Object>,
- *     entityJsonSchema: Object,
- * ) => Promise<any>}
- * */
-const sendSampleBatch = (connectionInfo, samples, entityJsonSchema) => {
+
+ * @param {Object} params - property bag
+ * @param {Object} params.connectionInfo
+ * @param {Array<Object>} params.samples
+ * @param {Object} params.entityJsonSchema
+ * @param {Object} params.logger
+ *
+ * @returns {Promise<any>}
+ */
+const sendSampleBatch = ({ connectionInfo, samples, entityJsonSchema, logger }) => {
 	const script = generateSamplesScript(entityJsonSchema, samples);
-	return executeCommand(connectionInfo, script, 'sql');
+	return executeCommand({ connectionInfo, command: script, logger });
 };
 
 /**
@@ -118,15 +122,17 @@ const logProgressOfSendingSampleBatches = logger => (lineIndex, amountOfLines) =
 	}
 
 	const progress = Number(lineIndex / amountOfLines);
+
 	const message =
 		lineIndex === 0
 			? `Start inserting data`
 			: `Inserted ${lineIndex} lines out of ${amountOfLines}, progress ${progress.toFixed(2)}%`;
+
 	logger.log('info', { message }, 'SEND_SAMPLE_BATCHES');
 	logger.progress({ message });
 };
 
-const sendSampleBatches = logger => async connectionInfo => {
+const sendSampleBatches = async ({ connectionInfo, logger }) => {
 	const { entitiesData } = connectionInfo;
 
 	for (const entityData of Object.values(entitiesData)) {
@@ -138,7 +144,7 @@ const sendSampleBatches = logger => async connectionInfo => {
 			batchSize: BATCH_SIZE,
 			parseLine: line => JSON.parse(line),
 			batchHandler: batch => {
-				return sendSampleBatch(connectionInfo, batch, jsonSchema);
+				return sendSampleBatch({ connectionInfo, samples: batch, entityJsonSchema: jsonSchema, logger });
 			},
 			logProgress: logProgressOfSendingSampleBatches(logger),
 		});
@@ -154,10 +160,10 @@ const fetchApplyToInstance = async (connectionInfo, logger) => {
 	progress({ message: `Applying script: \n ${connectionInfo.script}` });
 
 	await Promise.race([
-		executeCommand(connectionInfo, connectionInfo.script, 'sql').then(() => {
-			return sendSampleBatches(logger)(connectionInfo);
+		executeCommand({ connectionInfo, command: connectionInfo.script, logger }).then(() => {
+			return sendSampleBatches({ connectionInfo, logger });
 		}),
-		new Promise((_r, rej) =>
+		new Promise(() =>
 			setTimeout(() => {
 				throw new Error('Timeout exceeded for script\n' + connectionInfo.script);
 			}, connectionInfo.applyToInstanceQueryRequestTimeout || 120000),
@@ -170,11 +176,12 @@ const getSampleDocSize = async ({ connectionInfo, dbName, tableName, recordSampl
 		return Number(recordSamplingSettings.absolute.value);
 	}
 
-	const countResult = await executeCommand(
+	const countResult = await executeCommand({
 		connectionInfo,
-		`SELECT COUNT(*) FROM \`${dbName}\`.\`${tableName}\``,
-		'sql',
-	);
+		command: `SELECT COUNT(*) FROM \`${dbName}\`.\`${tableName}\``,
+		logger,
+	});
+
 	const count = _.get(countResult, '[0][0]', 0);
 	const limit = Math.ceil((count * recordSamplingSettings.relative.value) / 100);
 
@@ -194,7 +201,7 @@ const fetchDocuments = async ({ connectionInfo, dbName, tableName, fields, recor
 		const columnsToSelect = fields.map(field => field.name);
 		const columnsToSelectString = columnsToSelect.map(fieldName => `\`${fieldName}\``).join(', ');
 		const sqlQuery = `SELECT ${columnsToSelectString} FROM \`${dbName}\`.\`${tableName}\` LIMIT ${limit}`;
-		const documentsResult = await executeCommand(connectionInfo, sqlQuery, 'sql');
+		const documentsResult = await executeCommand({ connectionInfo, command: sqlQuery, logger });
 
 		logger.log('info', { message: `Execute query: ${sqlQuery}`, dbName, tableName }, 'Getting documents');
 
@@ -217,7 +224,7 @@ const fetchDocuments = async ({ connectionInfo, dbName, tableName, fields, recor
 const fetchEntitySchema = async ({ connectionInfo, dbName, entityName, logger }) => {
 	try {
 		const sqlQuery = `DESC \`${dbName}\`.\`${entityName}\``;
-		const schemaResult = await executeCommand(connectionInfo, sqlQuery, 'sql');
+		const schemaResult = await executeCommand({ connectionInfo, command: sqlQuery, logger });
 
 		logger.log('info', { message: `Execute query: ${sqlQuery}`, dbName, entityName }, 'Getting schema');
 
@@ -230,7 +237,11 @@ const fetchEntitySchema = async ({ connectionInfo, dbName, entityName, logger })
 				await prev;
 				const DATA_TYPE_COLUMN = 1;
 				const DATA_TYPE_ROW = 1;
-				const result = await executeCommand(connectionInfo, `${sqlQuery} \`${columnName}\``, 'sql');
+				const result = await executeCommand({
+					connectionInfo,
+					command: `${sqlQuery} \`${columnName}\``,
+					logger,
+				});
 				schemaResult[position][DATA_TYPE_COLUMN] = result[DATA_TYPE_ROW][DATA_TYPE_COLUMN];
 			}, Promise.resolve());
 		}
@@ -251,7 +262,7 @@ const fetchEntitySchema = async ({ connectionInfo, dbName, entityName, logger })
 const fetchSample = async ({ connectionInfo, dbName, entityName, logger }) => {
 	try {
 		const sqlQuery = `SELECT * FROM \`${dbName}\`.\`${entityName}\` LIMIT 1`;
-		const schemaResult = await executeCommand(connectionInfo, sqlQuery, 'sql');
+		const schemaResult = await executeCommand({ connectionInfo, command: sqlQuery, logger });
 
 		logger.log('info', { message: `Execute query: ${sqlQuery}`, dbName, entityName }, 'Fetching sample');
 
@@ -280,28 +291,29 @@ const fetchClusterProperties = async connectionInfo => {
 		});
 };
 
-const useCatalog = async connectionInfo => {
-	await executeCommand(connectionInfo, `USE CATALOG '${connectionInfo.catalogName}';`, 'sql');
+const useCatalog = async ({ connectionInfo, logger }) => {
+	const command = `USE CATALOG '${connectionInfo.catalogName}';`;
+	await executeCommand({ connectionInfo, command, logger });
 };
 
-const fetchClusterCatalogNames = async connectionInfo => {
-	const result = await executeCommand(connectionInfo, 'SHOW CATALOGS', 'sql');
+const fetchClusterCatalogNames = async ({ connectionInfo, logger }) => {
+	const result = await executeCommand({ connectionInfo, command: 'SHOW CATALOGS', logger });
 	return _.flattenDeep(result);
 };
 
-const fetchClusterDatabasesNames = async connectionInfo => {
-	const result = await executeCommand(connectionInfo, 'SHOW DATABASES', 'sql');
+const fetchClusterDatabasesNames = async ({ connectionInfo, logger }) => {
+	const result = await executeCommand({ connectionInfo, command: 'SHOW DATABASES', logger });
 	return _.flattenDeep(result);
 };
 
-const fetchDatabaseViewsNames = (dbName, connectionInfo) =>
-	executeCommand(connectionInfo, `SHOW VIEWS IN \`${dbName}\``, 'sql');
+const fetchDatabaseViewsNames = ({ dbName, connectionInfo, logger }) =>
+	executeCommand({ connectionInfo, command: `SHOW VIEWS IN \`${dbName}\``, logger });
 
-const fetchDatabaseViewsNamesViaPython = (dbName, connectionInfo) =>
-	executeCommand(connectionInfo, getViewNamesCommand(dbName), 'python');
+const fetchDatabaseViewsNamesViaPython = ({ dbName, connectionInfo, logger }) =>
+	executeCommand({ connectionInfo, command: getViewNamesCommand(dbName), language: 'python', logger });
 
-const fetchClusterTablesNames = (dbName, connectionInfo) =>
-	executeCommand(connectionInfo, `SHOW TABLES IN \`${dbName}\``, 'sql');
+const fetchClusterTablesNames = ({ dbName, connectionInfo, logger }) =>
+	executeCommand({ connectionInfo, command: `SHOW TABLES IN \`${dbName}\``, logger });
 
 const fetchClusterData = async (
 	connectionInfo,
@@ -312,13 +324,18 @@ const fetchClusterData = async (
 ) => {
 	const databasesPropertiesResult = await async.mapLimit(databasesNames, 40, async dbName => {
 		logger.log('info', '', `Start describe schema: ${dbName} `);
-		const dbInfoResult = await executeCommand(connectionInfo, `DESCRIBE DATABASE EXTENDED \`${dbName}\``, 'sql');
+		const dbInfoResult = await executeCommand({
+			connectionInfo,
+			command: `DESCRIBE DATABASE EXTENDED \`${dbName}\``,
+			logger,
+		});
 		logger.log('info', '', `Schema: ${dbName} successfully described`);
 		const dbProperties = dbInfoResult.reduce((dbProperties, row) => {
 			switch (row[0]) {
-				case 'Location':
+				case 'Location': {
 					const propertyName = isManagedLocationSupports ? 'managedLocation' : 'location';
 					return { ...dbProperties, [propertyName]: row[1] };
+				}
 				case 'Comment':
 					return { ...dbProperties, description: row[1] };
 				case 'Properties':
@@ -361,8 +378,8 @@ const splitJsonObjects = (jsonString = '') => jsonString.split(JSON_OBJECTS_DELI
  * @return {string}
  */
 const filterCorruptedEnd = corruptedJsonData => {
-	const splittedData = splitJsonObjects(corruptedJsonData);
-	return splittedData.slice(0, splittedData.length - 1).join(JSON_OBJECTS_DELIMITER);
+	const jsonObjects = splitJsonObjects(corruptedJsonData);
+	return jsonObjects.slice(0, jsonObjects.length - 1).join(JSON_OBJECTS_DELIMITER);
 };
 
 /**
@@ -370,8 +387,8 @@ const filterCorruptedEnd = corruptedJsonData => {
  * @return {string}
  */
 const filterCorruptedStart = corruptedJsonData => {
-	const splittedData = splitJsonObjects(corruptedJsonData);
-	return splittedData.slice(1).join(JSON_OBJECTS_DELIMITER);
+	const jsonObjects = splitJsonObjects(corruptedJsonData);
+	return jsonObjects.slice(1).join(JSON_OBJECTS_DELIMITER);
 };
 
 /**
@@ -397,7 +414,12 @@ const fetchFieldMetadata = async (databasesNames, collectionsNames, connectionIn
 		'',
 		`Start retrieving tables info: \nDatabases: ${dbNames.join(', ')} \nTables: ${tableNames.join(', ')}`,
 	);
-	const databasesTablesInfoResult = await executeCommand(connectionInfo, getClusterDataCommand, 'python');
+	const databasesTablesInfoResult = await executeCommand({
+		connectionInfo,
+		command: getClusterDataCommand,
+		language: 'python',
+		logger,
+	});
 	logger.log('info', '', `Finish retrieving tables info: ${databasesTablesInfoResult}`);
 
 	const isTruncatedResponse = /\*\*\* WARNING: skipped \d* bytes of output \*\*\*$/.test(databasesTablesInfoResult);
@@ -458,7 +480,7 @@ const mergeChunksOfData = (leftObj, rightObj) => {
 
 const fetchCreateStatementRequest = async (entityName, connectionInfo, logger) => {
 	try {
-		const result = await executeCommand(connectionInfo, `SHOW CREATE TABLE ${entityName};`, 'sql');
+		const result = await executeCommand({ connectionInfo, command: `SHOW CREATE TABLE ${entityName};`, logger });
 		return _.get(result, '[0][0]', '');
 	} catch (error) {
 		logger.log('error', error, `Error during retrieve create table DDL statement. Table name: ${entityName}`);
@@ -468,27 +490,27 @@ const fetchCreateStatementRequest = async (entityName, connectionInfo, logger) =
 
 const getRequestOptions = connectionInfo => {
 	const headers = {
-		'Authorization': 'Bearer ' + connectionInfo.accessToken,
+		Authorization: 'Bearer ' + connectionInfo.accessToken,
 	};
 
 	return {
-		'method': 'GET',
-		'headers': headers,
-		'timeout': connectionInfo.queryRequestTimeout,
-		'logger': connectionInfo.logger || { log: () => {} },
+		method: 'GET',
+		headers: headers,
+		timeout: connectionInfo.queryRequestTimeout,
+		logger: connectionInfo.logger || { log: () => {} },
 	};
 };
 
 const postRequestOptions = (connectionInfo, body) => {
 	const headers = {
 		'Content-Type': 'application/json',
-		'Authorization': 'Bearer ' + connectionInfo.accessToken,
+		Authorization: 'Bearer ' + connectionInfo.accessToken,
 	};
 
 	return {
-		'method': 'POST',
-		'timeout': connectionInfo.queryRequestTimeout,
-		'logger': connectionInfo.logger || { log: () => {} },
+		method: 'POST',
+		timeout: connectionInfo.queryRequestTimeout,
+		logger: connectionInfo.logger || { log: () => {} },
 		headers,
 		body,
 	};
@@ -500,8 +522,8 @@ const createContext = (connectionInfo, language) => {
 	}
 	const query = connectionInfo.host + '/api/1.2/contexts/create';
 	const body = JSON.stringify({
-		'language': language,
-		'clusterId': connectionInfo.clusterId,
+		language,
+		clusterId: connectionInfo.clusterId,
 	});
 	const options = postRequestOptions(connectionInfo, body);
 
@@ -530,8 +552,8 @@ const createContext = (connectionInfo, language) => {
 const destroyContext = (connectionInfo, contextId) => {
 	const query = connectionInfo.host + '/api/1.2/contexts/destroy';
 	const body = JSON.stringify({
-		'contextId': contextId,
-		'clusterId': connectionInfo.clusterId,
+		contextId: contextId,
+		clusterId: connectionInfo.clusterId,
 	});
 	const options = postRequestOptions(connectionInfo, body);
 	return fetch(query, options)
@@ -548,19 +570,25 @@ const destroyContext = (connectionInfo, contextId) => {
 			};
 		})
 		.then(body => {
-			body = JSON.parse(body);
+			return JSON.parse(body);
 		});
 };
 
-const runCommand = (connectionInfo, contextId, command, language) => {
+const runCommand = ({ connectionInfo, contextId, command, language, logger }) => {
+	const { clusterId } = connectionInfo;
 	const query = connectionInfo.host + '/api/1.2/commands/execute';
+
 	const commandOptions = JSON.stringify({
 		language,
-		clusterId: connectionInfo.clusterId,
+		clusterId,
 		contextId,
 		command,
 	});
+
 	const options = postRequestOptions(connectionInfo, commandOptions);
+
+	const notFinishedJob = err =>
+		[COMMAND_EXECUTION_STATUS.QUEUED, COMMAND_EXECUTION_STATUS.RUNNING].includes(err?.message);
 
 	return fetch(query, options)
 		.then(async response => {
@@ -576,17 +604,56 @@ const runCommand = (connectionInfo, contextId, command, language) => {
 			};
 		})
 		.then(body => {
-			body = JSON.parse(body);
+			const { id: commandId } = JSON.parse(body);
 
 			const query = new URL(connectionInfo.host + '/api/1.2/commands/status');
+
 			const params = {
-				clusterId: connectionInfo.clusterId,
-				contextId: contextId,
-				commandId: body.id,
+				clusterId,
+				contextId,
+				commandId,
 			};
+
 			query.search = new URLSearchParams(params).toString();
+
 			const options = getRequestOptions(connectionInfo);
-			return getCommandExecutionResult(query, options, commandOptions);
+			const request = () => getCommandExecutionResult({ query, options, commandOptions });
+
+			const extraAttempts = 3;
+			// The number of allowed requests within the preconfigured timeout (from global RE `queryRequestTimeout` option)
+			const numOfAttempts = Math.round(options.timeout / COMMAND_EXECUTION_MAX_DELAY) + extraAttempts;
+
+			const retry = (err, attemptNum) => {
+				if (attemptNum === numOfAttempts) {
+					logger.log('info', `max retries (${numOfAttempts}) exceeded`, 'API command progress');
+					return false;
+				}
+
+				if (notFinishedJob(err)) {
+					// log each 10 iteration
+					if (attemptNum % 10 === 0) {
+						const message = `Command ID: ${commandId}, status: ${err.message}, retry count: ${attemptNum}`;
+						logger.log('info', message, 'API command progress');
+					}
+
+					return true;
+				}
+			};
+
+			return backOff(request, {
+				// the job, usually, not available immediately
+				delayFirstAttempt: true,
+				maxDelay: COMMAND_EXECUTION_MAX_DELAY,
+				numOfAttempts,
+				retry,
+			});
+		})
+		.catch(err => {
+			if (notFinishedJob(err)) {
+				throw new Error(REQUEST_TIMEOUT_MESSAGE);
+			}
+
+			throw err;
 		});
 };
 
@@ -606,8 +673,15 @@ const getPythonSparkConfig = config => {
 		.join('\n');
 };
 
-const executeCommand = (connectionInfo, command, language = 'sql', logger) => {
+const executeCommand = ({ connectionInfo, command, language = 'sql', logger }) => {
 	return createContext(connectionInfo, language).then(async contextId => {
+		const payload = {
+			connectionInfo,
+			contextId,
+			language,
+			logger,
+		};
+
 		if (connectionInfo.sparkConfig && Object.keys(connectionInfo.sparkConfig).length) {
 			let sparkConfig;
 
@@ -618,17 +692,15 @@ const executeCommand = (connectionInfo, command, language = 'sql', logger) => {
 			}
 
 			if (sparkConfig) {
-				await runCommand(connectionInfo, contextId, sparkConfig, language);
+				await runCommand({ ...payload, command: sparkConfig });
 			}
 		}
 
-		const result = await runCommand(connectionInfo, contextId, command, language);
-
-		return result;
+		return await runCommand({ ...payload, command });
 	});
 };
 
-const getCommandExecutionResult = (query, options, commandOptions) => {
+const getCommandExecutionResult = ({ query, options, commandOptions }) => {
 	return fetch(query, options)
 		.then(async response => {
 			const responseBody = await response.text();
@@ -644,7 +716,8 @@ const getCommandExecutionResult = (query, options, commandOptions) => {
 		})
 		.then(body => {
 			body = JSON.parse(body);
-			if (body.status === 'Finished' && body.results !== null) {
+
+			if (body.status === COMMAND_EXECUTION_STATUS.FINISHED && body.results !== null) {
 				if (body.results.resultType === 'error') {
 					throw {
 						message: body.results.data || body.results.cause,
@@ -655,14 +728,16 @@ const getCommandExecutionResult = (query, options, commandOptions) => {
 				return body.results.data;
 			}
 
-			if (body.status === 'Error') {
+			if (body.status === COMMAND_EXECUTION_STATUS.ERROR) {
 				throw {
 					message: 'Error during receiving command result',
 					code: '',
 					description: commandOptions,
 				};
 			}
-			return getCommandExecutionResult(query, options, commandOptions);
+
+			// Should be handled correctly by `backOff` mechanism with the retry
+			throw new Error(body.status);
 		});
 };
 
@@ -721,21 +796,21 @@ const convertDbProperties = (dbProperties = '') => {
 		.join(',\n');
 };
 
-const getFetchForUnityTags = (connectionInfo, logger) => async query => {
-	try {
-		const language = 'sql';
+const getFetchForUnityTags =
+	({ connectionInfo, logger }) =>
+	async command => {
+		try {
+			return await executeCommand({ connectionInfo, command, logger });
+		} catch (error) {
+			logger.log('error', error, 'Error during retrieve tags');
 
-		return await executeCommand(connectionInfo, query, language);
-	} catch (error) {
-		logger.log('error', error, 'Error during retrieve tags');
-
-		return [];
-	}
-};
+			return [];
+		}
+	};
 
 const fetchTagsForUnityCatalogs = async (connectionInfo, logger) => {
 	try {
-		const fetchUnityTagsForSingleLevel = getFetchForUnityTags(connectionInfo, logger);
+		const fetchUnityTagsForSingleLevel = getFetchForUnityTags({ connectionInfo, logger });
 
 		const catalogTagsQuery = 'SELECT * FROM system.information_schema.catalog_tags;';
 		const schemaTagsQuery = 'SELECT * FROM system.information_schema.schema_tags;';

--- a/reverse_engineering/helpers/pythonScriptGeneratorHelper.js
+++ b/reverse_engineering/helpers/pythonScriptGeneratorHelper.js
@@ -1,3 +1,5 @@
+// --- Use only spaces in python script literals
+
 const getClusterData = (tablesNames, databasesNames) => `
 import json
 

--- a/shared/constants.js
+++ b/shared/constants.js
@@ -1,0 +1,17 @@
+// https://docs.databricks.com/api/azure/workspace/commandexecution/commandstatus#status
+const COMMAND_EXECUTION_STATUS = {
+	QUEUED: 'Queued',
+	RUNNING: 'Running',
+	CANCELLED: 'Cancelled',
+	CANCELLING: 'Cancelling',
+	ERROR: 'Error',
+	FINISHED: 'Finished',
+};
+
+const REQUEST_TIMEOUT_MESSAGE =
+	'Request timeout exceeded, please try again or increase query request timeout in Tools > Options > Reverse-Engineering';
+
+module.exports = {
+	COMMAND_EXECUTION_STATUS,
+	REQUEST_TIMEOUT_MESSAGE,
+};


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-12405" title="HCK-12405" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-12405</a>  Deltalake RE: executing python script for a long time doesn't respect "Request Timeout" option
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

* added proper timeout handling for deferred commands. Originally, the `AbortController` was never invoked for [recursive requests](https://github.com/hackolade/DeltaLake/blob/develop/reverse_engineering/helpers/fetchRequestHelper.js#L665), because fetch request of getting the job status was actually finished successfully, making subsequent new requests with a reinitialized timeout. Now we will [retry](https://github.com/hackolade/DeltaLake/pull/291/files#diff-d43a50181b8afbd123d0a5aaa11a8ef8bea3068b170c727ba0e64be2d2b63187R626) receiving the job status, with exponential delay, throwing our default [Request Timeout](https://github.com/hackolade/DeltaLake/pull/291/files#diff-d43a50181b8afbd123d0a5aaa11a8ef8bea3068b170c727ba0e64be2d2b63187R653) error eventually.
* extended the logs to reflect the progress of retries:

<details>
<summary>Regular retry</summary>

```
...
2025-08-19T16:14:46.529Z | Start describe schema: sap_ecc 
2025-08-19T16:14:47.098Z | Schema: sap_ecc successfully described
2025-08-19T16:14:47.098Z | Start retrieving tables info: 
Databases: "sap_ecc" 
Tables: "sap_ecc": ["sv_accounting_document_header"]
2025-08-19T16:15:12.914Z API command progress:
Command ID: a70dfda9f167421da2c04509c842f067, status: Running, retry count: 10

2025-08-19T16:15:50.295Z API command progress:
Command ID: a70dfda9f167421da2c04509c842f067, status: Running, retry count: 20

2025-08-19T16:16:27.860Z API command progress:
Command ID: a70dfda9f167421da2c04509c842f067, status: Running, retry count: 30

2025-08-19T16:16:35.150Z | Finish retrieving tables info: {"sap_ecc": [{"name": "sv_accounting_document_header", "nullableMap": {}, "indexes": {}}]}
2025-08-19T16:16:35.150Z Retrieving schema:
{
  "message": "Start getting entities ddl",
  "containerName": "databases",
  "entityName": "entities"
}
...
```

</details>

<details>
<summary> Timeout exceeded </summary>

```
2025-08-19T17:01:42.369Z | Start describe schema: sap_ecc 
2025-08-19T17:01:43.108Z | Schema: sap_ecc successfully described
2025-08-19T17:01:43.108Z | Start retrieving tables info: 
Databases: "sap_ecc" 
Tables: "sap_ecc": ["sv_accounting_document_header"]
2025-08-19T17:01:50.334Z API command progress:
max retries (5) exceeded

2025-08-19T17:01:50.334Z Reverse Engineering error:
{
  "error": {
    "stack": "Error: Request timeout exceeded, please try again or increase query request timeout in Tools > Options > Reverse-Engineering
    at /home/oleg/.hackolade/plugins/DeltaLake/reverse_engineering/helpers/fetchRequestHelper.js:653:11
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async /home/oleg/.hackolade/plugins/DeltaLake/reverse_engineering/helpers/fetchRequestHelper.js:699:10
    at async fetchFieldMetadata (/home/oleg/.hackolade/plugins/DeltaLake/reverse_engineering/helpers/fetchRequestHelper.js:417:36)
    at async Object.fetchClusterData (/home/oleg/.hackolade/plugins/DeltaLake/reverse_engineering/helpers/fetchRequestHelper.js:357:30)
    at async Object.getDbCollectionsData (/home/oleg/.hackolade/plugins/DeltaLake/reverse_engineering/api.js:202:24)
    at async callApiHandler (/home/oleg/Documents/hackolade/studio/dist-dev/reWorker.js:100:3)
    at async EventEmitter.<anonymous> (/home/oleg/Documents/hackolade/studio/dist-dev/reWorker.js:212:5)",
    "message": "Request timeout exceeded, please try again or increase query request timeout in Tools > Options > Reverse-Engineering"
  }
}
```

<img width="572" height="439" alt="image" src="https://github.com/user-attachments/assets/f77a27f8-0eba-4190-9ece-9a31c7647382" />
</details>


