### PR TITLE
HCK-12406: Cluster info in logs

### DIFF
--- a/reverse_engineering/api.js
+++ b/reverse_engineering/api.js
@@ -164,18 +164,19 @@ module.exports = {
 			logger.log('info', message, 'Retrieving schema', data.hiddenKeys);
 			logger.progress(message);
 		};
-		let modelData;
+
+		let clusterState;
 
 		try {
-			modelData = await databricksHelper.getClusterStateInfo(connectionData, logger);
-			logger.log('info', modelData, 'Cluster state info');
+			clusterState = await databricksHelper.getClusterStateInfo(connectionData, logger);
+			logger.log('info', { clusterState }, 'Cluster state info');
 
 			const collections = data.collectionData.collections;
 			const dataBaseNames = data.collectionData.dataBaseNames;
 			const fieldInference = data.fieldInference;
-			const isUnityCatalogSupports = isSupportUnityCatalog(modelData.spark_version);
+			const isUnityCatalogSupports = isSupportUnityCatalog(clusterState.spark_version);
 			const isUnityCatalogEnabled =
-				isUnityCatalogSupports && databricksHelper.isEnabledUnityCatalog(modelData.data_security_mode);
+				isUnityCatalogSupports && databricksHelper.isEnabledUnityCatalog(clusterState.data_security_mode);
 
 			if (!isUnityCatalogEnabled) {
 				logger.log('info', '', 'Unity Catalog is disabled');
@@ -209,7 +210,7 @@ module.exports = {
 				connectionData,
 				dataBaseNames,
 				collections,
-				modelData.spark_version,
+				clusterState.spark_version,
 				logger,
 			);
 			const ddlByEntity = entitiesDdl.reduce((ddlByEntity, ddlObject) => {
@@ -319,7 +320,7 @@ module.exports = {
 
 				const viewsNames = dataBaseNames.reduce((viewsNames, dbName) => {
 					const views = (collections[dbName] || [])
-						.map(entityName => cleanEntityName(modelData.spark_version, entityName))
+						.map(entityName => cleanEntityName(clusterState.spark_version, entityName))
 						.filter(entityName => isViewDdl(ddlByEntity[`${dbName}.${entityName}`]));
 
 					return { ...viewsNames, [dbName]: views };
@@ -418,15 +419,16 @@ module.exports = {
 			fetchRequestHelper.destroyActiveContext();
 
 			if (warnings.length) {
-				modelData = {
-					...(modelData || {}),
+				clusterState = {
+					...(clusterState || {}),
 					warning: createWarning(warnings),
 				};
 			}
 
-			cb(null, packages, modelData, relationships);
+			cb(null, packages, clusterState, relationships);
 		} catch (err) {
-			const clusterState = modelData || (await databricksHelper.getClusterStateInfo(connectionData, logger));
+			clusterState ??= await databricksHelper.getClusterStateInfo(connectionData, logger);
+
 			if (!clusterState.isRunning) {
 				logger.log(
 					'error',


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-12406" title="HCK-12406" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-12406</a>  Deltalake RE: cluster info is missing in the logs
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

* prevent cluster info from being trimmed by the app's 'duplicated connection info' [filter](https://github.com/hackolade/studio/blob/develop/RE_API/helpers/callApiHandler.js#L17)

<details>
<summary> log example </summary>

```
2025-08-19T17:47:12.257Z Cluster state info:
{
  "clusterState": {
    "dbVersion": "Runtime 16",
    "modelName": "Oleg Cluster 2025-08-19 10:05:32",
    "author": "oleg.chulanovskyi@hackolade.com",
    "host": "https://adb-1022242077105723.3.azuredatabricks.net",
    "port": 10000,
    "cluster_name": "Oleg Cluster 2025-08-19 10:05:32",
    "min_workers": 0,
    "max_workers": 0,
    "spark_version": "16.4.x-scala2.12",
    "spark_conf": "{\"spark.master\":\"local[*, 4]\",\"spark.databricks.cluster.profile\":\"singleNode\"}",
    "node_type_id": "Standard_F4",
    "driver_node_type_id": "Standard_F4",
    "custom_tags": [
      {
        "customTagKey": "ResourceClass",
        "customtagvalue": "SingleNode"
      }
    ],
    "autotermination_minutes": 120,
    "enable_elastic_disk": true,
    "isRunning": true,
    "state": "RUNNING",
    "data_security_mode": "USER_ISOLATION"
  }
}

```

</details>