### PR TITLE
HCK-12406: cluster info in logs

### DIFF
--- a/reverse_engineering/api.js
+++ b/reverse_engineering/api.js
@@ -44,8 +44,10 @@ module.exports = {
 			};
 
 			logInfo('Test connection RE', connectionInfo, logger);
+
 			const clusterState = await databricksHelper.getClusterStateInfo(connectionData, logger);
 			logger.log('info', { clusterState }, 'Cluster state info');
+
 			await databricksHelper.getFirstDatabaseCollectionName(connectionData, clusterState.spark_version, logger);
 
 			if (!clusterState.isRunning) {
@@ -71,6 +73,7 @@ module.exports = {
 				logger,
 			};
 			const clusterState = await databricksHelper.getClusterStateInfo(connectionData, logger);
+			logger.log('info', { clusterState }, 'Cluster state info');
 
 			let catalogNames = [];
 
@@ -122,7 +125,6 @@ module.exports = {
 
 			const clusterState = await databricksHelper.getClusterStateInfo(connectionData, logger);
 
-			logger.log('info', { clusterState }, 'Cluster state info');
 			const dbCollectionsNames = await databricksHelper.getDatabaseCollectionNames(
 				connectionData,
 				clusterState.spark_version,
@@ -172,7 +174,6 @@ module.exports = {
 
 		try {
 			clusterState = await databricksHelper.getClusterStateInfo(connectionData, logger);
-			logger.log('info', { clusterState }, 'Cluster state info');
 
 			const collections = data.collectionData.collections;
 			const dataBaseNames = data.collectionData.dataBaseNames;

--- a/reverse_engineering/api.js
+++ b/reverse_engineering/api.js
@@ -45,7 +45,7 @@ module.exports = {
 
 			logInfo('Test connection RE', connectionInfo, logger);
 			const clusterState = await databricksHelper.getClusterStateInfo(connectionData, logger);
-			logger.log('info', clusterState, 'Cluster state info');
+			logger.log('info', { clusterState }, 'Cluster state info');
 			await databricksHelper.getFirstDatabaseCollectionName(connectionData, clusterState.spark_version, logger);
 
 			if (!clusterState.isRunning) {
@@ -122,7 +122,7 @@ module.exports = {
 
 			const clusterState = await databricksHelper.getClusterStateInfo(connectionData, logger);
 
-			logger.log('info', clusterState, 'Cluster state info');
+			logger.log('info', { clusterState }, 'Cluster state info');
 			const dbCollectionsNames = await databricksHelper.getDatabaseCollectionNames(
 				connectionData,
 				clusterState.spark_version,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-12406" title="HCK-12406" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-12406</a>  Deltalake RE: cluster info is missing in the logs
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

* prevent cluster info from being trimmed by the app's 'duplicated connection info' filter