### PR TITLE
HCK-14106: fix the generation of an alter script for clustering keys if new values ​​do not exist

### DIFF
--- a/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/modifyCollectionScript.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/modifyCollectionScript.js
@@ -145,13 +145,10 @@ const getModifyClusteringScriptDto =
 	({ collection, dbVersion }) => {
 		const compMod = _.get(collection, 'role.compMod', {});
 		const compositeClusteringKeys = _.get(compMod, 'compositeClusteringKey', {});
-		const oldCompositeClusteringKeys = compositeClusteringKeys.old;
-		const newCompositeClusteringKeys = compositeClusteringKeys.new;
+		const oldCompositeClusteringKeys = compositeClusteringKeys.old ?? [];
+		const newCompositeClusteringKeys = compositeClusteringKeys.new ?? [];
 
-		if (
-			!Array.isArray(newCompositeClusteringKeys) ||
-			_.isEqual(oldCompositeClusteringKeys, newCompositeClusteringKeys)
-		) {
+		if (_.isEqual(oldCompositeClusteringKeys, newCompositeClusteringKeys)) {
 			return;
 		}
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-14106" title="HCK-14106" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-14106</a>  [DeltaLake]: Fix altering clustering keys if property no longer exist
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

If the array with the new keys does not exist in the right model, then the clustering value should be `NONE`