### PR TITLE
HCK-14681: Preserve model objects for streaming tables when using separate statements in FE

### DIFF
--- a/forward_engineering/config.json
+++ b/forward_engineering/config.json
@@ -68,7 +68,32 @@
 					},
 					"defaultValue": {
 						"primaryKey": []
-					}
+					},
+					"applyToValue": "ignore"
+				},
+				{
+					"dependency": {
+						"type": "and",
+						"values": [
+							{
+								"key": "primaryKey",
+								"valueType": "array"
+							},
+							{
+								"type": "not",
+								"values": [
+									{
+										"key": "streamingTable",
+										"value": true
+									}
+								]
+							}
+						]
+					},
+					"defaultValue": {
+						"primaryKey": []
+					},
+					"applyToValue": "separate"
 				},
 				{
 					"dependency": {
@@ -87,7 +112,43 @@
 					"defaultValue": {
 						"primaryKey": false,
 						"compositePrimaryKey": false
-					}
+					},
+					"applyToValue": "ignore"
+				},
+				{
+					"dependency": {
+						"type": "and",
+						"values": [
+							{
+								"type": "or",
+								"values": [
+									{
+										"key": "primaryKey",
+										"value": true
+									},
+									{
+										"key": "compositePrimaryKey",
+										"value": true
+									}
+								]
+							},
+							{
+								"type": "not",
+								"values": [
+									{
+										"level": "root",
+										"key": "streamingTable",
+										"value": true
+									}
+								]
+							}
+						]
+					},
+					"defaultValue": {
+						"primaryKey": false,
+						"compositePrimaryKey": false
+					},
+					"applyToValue": "separate"
 				}
 			]
 		},
@@ -164,7 +225,33 @@
 					},
 					"defaultValue": {
 						"required": false
-					}
+					},
+					"applyToValue": "ignore"
+				},
+				{
+					"dependency": {
+						"type": "and",
+						"values": [
+							{
+								"key": "required",
+								"value": true
+							},
+							{
+								"type": "not",
+								"values": [
+									{
+										"level": "root",
+										"key": "streamingTable",
+										"value": true
+									}
+								]
+							}
+						]
+					},
+					"defaultValue": {
+						"required": false
+					},
+					"applyToValue": "separate"
 				}
 			]
 		},
@@ -251,7 +338,33 @@
 					},
 					"defaultValue": {
 						"default": ""
-					}
+					},
+					"applyToValue": "ignore"
+				},
+				{
+					"dependency": {
+						"type": "and",
+						"values": [
+							{
+								"key": "default",
+								"exist": true
+							},
+							{
+								"type": "not",
+								"values": [
+									{
+										"level": "root",
+										"key": "streamingTable",
+										"value": true
+									}
+								]
+							}
+						]
+					},
+					"defaultValue": {
+						"default": ""
+					},
+					"applyToValue": "separate"
 				}
 			]
 		},
@@ -326,7 +439,36 @@
 					},
 					"defaultValue": {
 						"description": ""
-					}
+					},
+					"applyToValue": "ignore"
+				},
+				{
+					"dependency": {
+						"type": "and",
+						"values": [
+							{
+								"key": "collectionName",
+								"exist": true
+							},
+							{
+								"key": "description",
+								"exist": true
+							},
+							{
+								"type": "not",
+								"values": [
+									{
+										"key": "streamingTable",
+										"value": true
+									}
+								]
+							}
+						]
+					},
+					"defaultValue": {
+						"description": ""
+					},
+					"applyToValue": "separate"
 				}
 			]
 		},
@@ -414,7 +556,50 @@
 					},
 					"defaultValue": {
 						"description": ""
-					}
+					},
+					"applyToValue": "ignore"
+				},
+				{
+					"dependency": {
+						"type": "and",
+						"values": [
+							{
+								"type": "not",
+								"values": [
+									{
+										"key": "type",
+										"value": "bucket"
+									}
+								]
+							},
+							{
+								"key": "collectionName",
+								"exist": false
+							},
+							{
+								"key": "viewOn",
+								"exist": false
+							},
+							{
+								"key": "description",
+								"exist": true
+							},
+							{
+								"type": "not",
+								"values": [
+									{
+										"level": "root",
+										"key": "streamingTable",
+										"value": true
+									}
+								]
+							}
+						]
+					},
+					"defaultValue": {
+						"description": ""
+					},
+					"applyToValue": "separate"
 				}
 			]
 		}

--- a/forward_engineering/config.json
+++ b/forward_engineering/config.json
@@ -172,7 +172,19 @@
 					"disabled": false,
 					"disabledLabel": ""
 				}
-			}
+			},
+			"filterAdapters": [
+				{
+					"applyToValue": "separate",
+					"adapter": "preserveRelationshipsForTablesMatchingDependency",
+					"adapterProps": {
+						"dependency": {
+							"key": "streamingTable",
+							"value": true
+						}
+					}
+				}
+			]
 		},
 		{
 			"keyword": "uniqueConstraints",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-14681" title="HCK-14681" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-14681</a>  Adjust script generation options functionality for streaming tables
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

In this PR, I extended the script generation options configuration to allow preserving model objects for streaming tables when the selected option is “In separate statement.” Streaming tables do not support `ALTER` operations, so all required properties must be included during table creation.

**What was adjusted:**
- Primary keys
- Column `NOT NULL` constraints
- Column default values
- Table comments
- Schema comments
- Foreign keys — a special case, since relationships between streaming tables must be preserved. This behavior cannot be configured through existing options, so a new app adapter was introduced to handle it.