### PR TITLE
HCK-14471: inline FK ans Alter clauses for Streaming tables

### DIFF
--- a/forward_engineering/alterScript/alterScriptFromDeltaHelper.js
+++ b/forward_engineering/alterScript/alterScriptFromDeltaHelper.js
@@ -29,6 +29,7 @@ const {
 	getContainerName,
 	replaceSpaceWithUnderscore,
 	prepareName,
+	executeUnlessStreaming,
 } = require('../utils/general');
 const { getModifyPkConstraintsScripts } = require('./alterScriptHelpers/entityHelpers/primaryKeyHelper');
 const { getAlterRelationshipsScriptDtos } = require('./alterScriptHelpers/alterRelationshipsHelper');
@@ -170,7 +171,13 @@ const getAlterCollectionsScriptDtos = ({ schema, definitions, provider, data, ap
 
 		if (getDBVersionNumber(dbVersion) >= Runtime.RUNTIME_SUPPORTING_PK_FK_CONSTRAINTS) {
 			modifiedCollectionPrimaryKeysScriptDtos = getItems(schema, 'entities', 'modified').flatMap(collection => {
-				const scripts = getModifyPkConstraintsScripts(provider)({ collection, dbVersion });
+				const isStreaming = collection?.role?.streamingTable;
+
+				const scripts = executeUnlessStreaming(
+					isStreaming,
+					() => getModifyPkConstraintsScripts(provider)({ collection, dbVersion }),
+					[],
+				);
 
 				return wrapWithUseSchema(getSchemaName(collection), scripts);
 			});

--- a/forward_engineering/alterScript/alterScriptHelpers/alterEntityHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/alterEntityHelper.js
@@ -11,6 +11,7 @@ const {
 	getContainerName,
 	isSupportUnityCatalog,
 	isSupportNotNullConstraints,
+	executeUnlessStreaming,
 } = require('../../utils/general');
 const { getModifyCollectionCommentsScripts } = require('./entityHelpers/commentsHelper');
 const { getCheckConstraintsScriptDtos } = require('./columnHelpers/checkConstraintHelper');
@@ -150,11 +151,19 @@ const getDeleteColumnsScripts = (app, definitions, provider, dbVersion) => entit
 	const properties = getEntityProperties(entity);
 	const columnStatement = getColumnsString(Object.keys(columns));
 	const fullCollectionName = generateFullEntityName({ entity, dbVersion });
+
+	const isStreaming = entity?.role?.streamingTable;
+
 	const { hydratedAddIndex, hydratedDropIndex } = hydrateIndex({ entity, properties, definitions, dbVersion });
 	const modifyScript = generateModifyCollectionScript(app)(entity, definitions, provider, dbVersion);
 	const dropIndexScript = provider.dropTableIndex(hydratedDropIndex);
 	const addIndexScript = getIndexes(...hydratedAddIndex);
-	const deleteColumnScript = provider.dropTableColumns({ name: fullCollectionName, columns: columnStatement });
+
+	const deleteColumnScript = executeUnlessStreaming(
+		isStreaming,
+		() => provider.dropTableColumns({ name: fullCollectionName, columns: columnStatement }),
+		'',
+	);
 
 	const dropIndexScriptDto = AlterScriptDto.getInstance([dropIndexScript], true, true);
 	const addIndexScriptDto = AlterScriptDto.getInstance([addIndexScript], true, false);
@@ -201,7 +210,14 @@ const getModifyColumnsScripts = (app, definitions, ddlProvider, dbVersion) => co
 		},
 	};
 	const hydratedAlterColumnName = hydrateAlterColumnName({ entity: collection, properties, dbVersion });
-	const alterColumnScripts = ddlProvider.alterTableColumnName(hydratedAlterColumnName);
+
+	const isStreaming = collection?.role?.streamingTable;
+	const alterColumnScripts = executeUnlessStreaming(
+		isStreaming,
+		() => ddlProvider.alterTableColumnName(hydratedAlterColumnName),
+		[],
+	);
+
 	const modifiedScript = generateModifyCollectionScript(app)(entityData, definitions, ddlProvider, dbVersion);
 	const { hydratedAddIndex, hydratedDropIndex } = hydrateIndex({
 		entity: collection,
@@ -216,15 +232,32 @@ const getModifyColumnsScripts = (app, definitions, ddlProvider, dbVersion) => co
 		collection,
 		dbVersion,
 	});
-	const modifyNotNullConstraintsScriptDtos = getModifyNonNullColumnsScriptDtos(ddlProvider)({
-		collection,
-		dbVersion,
-	});
-	const modifyCheckConstraintsScriptDtos = getCheckConstraintsScriptDtos(ddlProvider)({ collection, dbVersion });
-	const modifiedDefaultColumnValueScriptDtos = getModifiedDefaultColumnValueScriptDtos(ddlProvider)({
-		collection,
-		dbVersion,
-	});
+
+	const modifyNotNullConstraintsScriptDtos = executeUnlessStreaming(
+		isStreaming,
+		() =>
+			getModifyNonNullColumnsScriptDtos(ddlProvider)({
+				collection,
+				dbVersion,
+			}),
+		[],
+	);
+
+	const modifyCheckConstraintsScriptDtos = executeUnlessStreaming(
+		isStreaming,
+		() => getCheckConstraintsScriptDtos(ddlProvider)({ collection, dbVersion }),
+		[],
+	);
+
+	const modifiedDefaultColumnValueScriptDtos = executeUnlessStreaming(
+		isStreaming,
+		() =>
+			getModifiedDefaultColumnValueScriptDtos(ddlProvider)({
+				collection,
+				dbVersion,
+			}),
+		[],
+	);
 
 	const dropIndexScriptDto = AlterScriptDto.getInstance([dropIndexScript], true, true);
 	const addIndexScriptDto = AlterScriptDto.getInstance([addIndexScript], true, false);
@@ -240,7 +273,11 @@ const getModifyColumnsScripts = (app, definitions, ddlProvider, dbVersion) => co
 		return [dropIndexScriptDto, addIndexScriptDto].filter(Boolean);
 	}
 
-	const updateTypeScriptDtos = getUpdateTypesScriptDtos(ddlProvider)(collection, definitions, dbVersion);
+	const updateTypeScriptDtos = executeUnlessStreaming(
+		isStreaming,
+		() => getUpdateTypesScriptDtos(ddlProvider)(collection, definitions, dbVersion),
+		[],
+	);
 
 	return [
 		dropIndexScriptDto,
@@ -272,8 +309,15 @@ const getModifyColumnsScriptsForOlderRuntime = (app, definitions, ddlProvider, d
 			properties: Object.fromEntries(unionProperties),
 		},
 	};
+
+	const isStreaming = collection?.role?.streamingTable;
 	const hydratedAlterColumnName = hydrateAlterColumnName({ entity: collection, properties, dbVersion });
-	const alterColumnScripts = ddlProvider.alterTableColumnName(hydratedAlterColumnName);
+	const alterColumnScripts = executeUnlessStreaming(
+		isStreaming,
+		() => ddlProvider.alterTableColumnName(hydratedAlterColumnName),
+		[],
+	);
+
 	const modifiedScript = generateModifyCollectionScript(app)(entityData, definitions, ddlProvider, dbVersion);
 	const { hydratedAddIndex, hydratedDropIndex } = hydrateIndex({
 		entity: collection,
@@ -293,7 +337,12 @@ const getModifyColumnsScriptsForOlderRuntime = (app, definitions, ddlProvider, d
 		collection,
 		dbVersion,
 	});
-	const modifyCheckConstraintsScriptDtos = getCheckConstraintsScriptDtos(ddlProvider)({ collection, dbVersion });
+
+	const modifyCheckConstraintsScriptDtos = executeUnlessStreaming(
+		isStreaming,
+		() => getCheckConstraintsScriptDtos(ddlProvider)({ collection, dbVersion }),
+		[],
+	);
 
 	let tableModificationScriptDtos = [];
 	if (!_.isEmpty(columnsToDelete)) {

--- a/forward_engineering/alterScript/alterScriptHelpers/alterRelationshipsHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/alterRelationshipsHelper.js
@@ -1,9 +1,11 @@
+const _ = require('lodash');
 const {
 	getFullEntityName,
 	replaceSpaceWithUnderscore,
 	prepareName,
 	getContainerName,
 	replaceDotWithUnderscore,
+	executeUnlessStreaming,
 } = require('../../utils/general');
 const { AlterScriptDto } = require('../types/AlterScriptDto');
 const { getUseSchemaScriptDto } = require('./alterEntityHelper');
@@ -117,13 +119,24 @@ const canRelationshipBeDeleted = relationship => {
 };
 
 /**
- * @return {(deletedRelationships: Array<Object>) => Array<AlterScriptDto>}
+ * @param {Object} ddlProvider - The DDL provider instance.
+ * @return {(deletedRelationships: Array<Object>, entities: Object.<string, Object>) => Array<{isActivated: boolean, scripts: Array<{script: string, isDropScript: boolean}>}>}
  * */
-const getDeleteForeignKeyScripts = ddlProvider => deletedRelationships => {
+const getDeleteForeignKeyScripts = ddlProvider => (deletedRelationships, entities) => {
 	return deletedRelationships
 		.filter(relationship => canRelationshipBeDeleted(relationship))
 		.map(relationship => {
-			const script = getDeleteSingleForeignKeyScript(ddlProvider)(relationship);
+			const childId = relationship?.role?.childCollection;
+			const childTable = entities[childId];
+
+			const isStreaming = childTable?.role?.streamingTable;
+
+			const script = executeUnlessStreaming(
+				isStreaming,
+				() => getDeleteSingleForeignKeyScript(ddlProvider)(relationship),
+				'',
+			);
+
 			return {
 				isActivated: Boolean(relationship.role?.compMod?.isActivated?.new),
 				scripts: [
@@ -161,6 +174,14 @@ const getModifyForeignKeyScript = ddlProvider => relationship => {
 
 const getAlterRelationshipsScriptDtos = ({ schema, ddlProvider, initialSchemaName }) => {
 	let currentSchemaName = initialSchemaName;
+
+	const allEntitiesArray = [
+		...getItems(schema, 'entities', 'added'),
+		...getItems(schema, 'entities', 'modified'),
+		...getItems(schema, 'entities', 'deleted'),
+	];
+
+	const allEntities = _.keyBy(allEntitiesArray, item => item?.role?.id);
 
 	const generateAddFkScriptDtos = (addedRelationships, getScript) => {
 		return addedRelationships.filter(relationship => canRelationshipBeAdded(relationship)).flatMap(getScript);
@@ -204,7 +225,7 @@ const getAlterRelationshipsScriptDtos = ({ schema, ddlProvider, initialSchemaNam
 	);
 	const modifiedRelationships = getItems(schema, 'relationships', 'modified');
 
-	const deleteFkScripts = getDeleteForeignKeyScripts(ddlProvider)(deletedRelationships);
+	const deleteFkScripts = getDeleteForeignKeyScripts(ddlProvider)(deletedRelationships, allEntities);
 	const addFkScripts = getRelationshipsScriptsWithUseSchema(
 		addedRelationships,
 		generateAddFkScriptDtos,

--- a/forward_engineering/alterScript/alterScriptHelpers/columnHelpers/alterUnityTagsHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/columnHelpers/alterUnityTagsHelper.js
@@ -28,10 +28,12 @@ const getSetUnityColumnTagsDtos =
 			return [];
 		}
 
-		const script = ddlProvider.setColumnTags({ tableName, columnName, tags: buildTagPairs(setTags) });
+		const isStreaming = entityData?.role?.streamingTable;
+
+		const script = ddlProvider.setColumnTags({ tableName, columnName, tags: buildTagPairs(setTags), isStreaming });
 
 		return [AlterScriptDto.getInstance([script], true, false)];
-	}; //
+	};
 
 /**
  * @param ddlProvider {Object}
@@ -53,10 +55,13 @@ const getUnsetUnityColumnTagsScriptsDtosFrom =
 			return [];
 		}
 
+		const isStreaming = entityData?.role?.streamingTable;
+
 		const script = ddlProvider.unsetColumnTags({
 			tableName,
 			columnName,
 			tags: getUnsetTagsNamesParamString({ unsetTags }),
+			isStreaming,
 		});
 
 		return [AlterScriptDto.getInstance([script], true, true)];

--- a/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/addColumnsHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/addColumnsHelper.js
@@ -5,6 +5,7 @@ const {
 	generateFullEntityName,
 	prepareName,
 	getDBVersionNumber,
+	executeUnlessStreaming,
 } = require('../../../utils/general');
 const { getIndexes } = require('../../../helpers/indexHelper');
 const { AlterScriptDto } = require('../../types/AlterScriptDto');
@@ -66,6 +67,8 @@ const getAddColumnsScriptsForModifyModifyCollectionScript = provider => (entity,
 	const entityData = { ...entity, ..._.omit(entity.role, ['properties']) };
 	const { columns } = getColumns(entityData, definitions, dbVersion);
 
+	const isStreaming = entityData?.streamingTable;
+
 	// "NOT NULL" constraint is baked right into the "column statement". We are unsetting "not null" constraint
 	// property on each column so that we could add these constraints in separate statements and not have it duplicated.
 	const columnsWithoutNotNull = getColumnsWithoutNotNullConstraint(columns);
@@ -76,10 +79,17 @@ const getAddColumnsScriptsForModifyModifyCollectionScript = provider => (entity,
 	const { hydratedAddIndex, hydratedDropIndex } = hydrateIndex({ entity, properties, definitions, dbVersion });
 	const dropIndexScript = provider.dropTableIndex(hydratedDropIndex);
 	const addIndexScript = getIndexes(...hydratedAddIndex);
-	const addColumnScript = provider.addTableColumns({ name: fullCollectionName, columns: columnStatement });
+
+	const addColumnScript = executeUnlessStreaming(
+		isStreaming,
+		() => provider.addTableColumns({ name: fullCollectionName, columns: columnStatement }),
+		'',
+	);
 
 	const isUnityTagsSupported = getDBVersionNumber(dbVersion) >= Runtime.MINIMUM_UNITY_TAGS_SUPPORT_VERSION;
-	const columnsUnityTagsScript = isUnityTagsSupported ? getColumnTagsStatement(properties, fullCollectionName) : [];
+	const columnsUnityTagsScript = isUnityTagsSupported
+		? getColumnTagsStatement(properties, fullCollectionName, isStreaming)
+		: [];
 	const addColumnScriptWithUnityTags = isUnityTagsSupported
 		? [addColumnScript, ...columnsUnityTagsScript].join('\n')
 		: addColumnScript;

--- a/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/alterUnityTagsHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/alterUnityTagsHelper.js
@@ -27,11 +27,13 @@ const getSetUnityEntityTagsDtos =
 
 		const setTags = getUnityTagsFromCompMod({ tagsToFilter: newUnityTags, filterBy: oldUnityTags });
 
+		const isStreaming = entityData?.role?.streamingTable;
+
 		if (!setTags.length) {
 			return [];
 		}
 
-		const script = ddlProvider.setEntityTags({ name, tags: buildTagPairs(setTags) });
+		const script = ddlProvider.setEntityTags({ name, tags: buildTagPairs(setTags), isStreaming });
 
 		return [AlterScriptDto.getInstance([script], true, false)];
 	};
@@ -49,11 +51,17 @@ const getUnsetUnityEntityTagsScriptsDtosFrom =
 
 		const unsetTags = getUnityTagsFromCompMod({ tagsToFilter: oldUnityTags, filterBy: newUnityTags });
 
+		const isStreaming = entityData?.role?.streamingTable;
+
 		if (!unsetTags.length) {
 			return [];
 		}
 
-		const script = ddlProvider.unsetEntityTags({ name, tags: getUnsetTagsNamesParamString({ unsetTags }) });
+		const script = ddlProvider.unsetEntityTags({
+			name,
+			tags: getUnsetTagsNamesParamString({ unsetTags }),
+			isStreaming,
+		});
 
 		return [AlterScriptDto.getInstance([script], true, true)];
 	};

--- a/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/modifyCollectionScript.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/modifyCollectionScript.js
@@ -11,6 +11,7 @@ const {
 	isSupportUnityCatalog,
 	isSupportNotNullConstraints,
 	checkLiquidClusteringPropertyChanged,
+	executeUnlessStreaming,
 } = require('../../../utils/general');
 const { getTableStatement } = require('../../../helpers/tableHelper');
 const { AlterScriptDto } = require('../../types/AlterScriptDto');
@@ -173,20 +174,54 @@ const getModifyCollectionScriptDtos =
 		const compMod = _.get(collection, 'role.compMod', {});
 		const fullCollectionName = generateFullEntityName({ entity: collection, dbVersion });
 
-		const alterTableNameScript = ddlProvider.alterTableName(hydrateAlterTableName(compMod));
+		const isStreaming = collection?.role?.streamingTable;
+
+		const alterTableNameScript = executeUnlessStreaming(
+			isStreaming,
+			() => ddlProvider.alterTableName(hydrateAlterTableName(compMod)),
+			'',
+		);
+
 		const hydratedSerDeProperties = hydrateSerDeProperties(compMod, fullCollectionName);
-		const checkConstraintsDtos = getModifyCheckConstraintsScriptDtos(ddlProvider)(fullCollectionName, collection);
-		const tablePropertiesScriptDtos = getModifiedTablePropertiesScriptDtos(ddlProvider)({ collection, dbVersion });
-		const serDeProperties = ddlProvider.alterSerDeProperties(hydratedSerDeProperties);
-		const modifyLocationScriptDto = getModifyLocationScriptDto(app, ddlProvider)({ collection, dbVersion });
+
+		const checkConstraintsDtos = executeUnlessStreaming(
+			isStreaming,
+			() => getModifyCheckConstraintsScriptDtos(ddlProvider)(fullCollectionName, collection),
+			[],
+		);
+
+		const tablePropertiesScriptDtos = executeUnlessStreaming(
+			isStreaming,
+			() => getModifiedTablePropertiesScriptDtos(ddlProvider)({ collection, dbVersion }),
+			[],
+		);
+
+		const serDeProperties = executeUnlessStreaming(
+			isStreaming,
+			() => ddlProvider.alterSerDeProperties(hydratedSerDeProperties),
+			'',
+		);
+
+		const modifyLocationScriptDto = executeUnlessStreaming(
+			isStreaming,
+			() => getModifyLocationScriptDto(app, ddlProvider)({ collection, dbVersion }),
+			undefined,
+		);
+
 		const unityEntityTagsDtos = getModifyUnityEntityTagsScriptDtos({ ddlProvider })({
 			entityData: collection,
 			name: fullCollectionName,
 		});
-		const checkLiquidClusteringScriptDtos = getModifyClusteringScriptDto({ ddlProvider })({
-			collection,
-			dbVersion,
-		});
+
+		const checkLiquidClusteringScriptDtos = executeUnlessStreaming(
+			isStreaming,
+			() =>
+				getModifyClusteringScriptDto({ ddlProvider })({
+					collection,
+					dbVersion,
+				}),
+			undefined,
+		);
 
 		return {
 			type: 'modify',

--- a/forward_engineering/ddlProvider/ddlProvider.js
+++ b/forward_engineering/ddlProvider/ddlProvider.js
@@ -422,21 +422,29 @@ module.exports = app => {
 		},
 
 		/**
-		 * @param name {string}
-		 * @param tags {string}
+		 * @param {Object} params
+		 * @param {string} params.name
+		 * @param {string} params.tags
+		 * @param {boolean} [params.isStreaming]
 		 * @return {string}
 		 * */
-		setEntityTags({ name, tags }) {
-			return assignTemplates(templates.setTableTags, { name, tags });
+		setEntityTags({ name, tags, isStreaming }) {
+			return assignTemplates(templates.setTableTags, { name, tags, streaming: isStreaming ? 'STREAMING ' : '' });
 		},
 
 		/**
-		 * @param name {string}
-		 * @param tags {string}
+		 * @param {Object} params
+		 * @param {string} params.name
+		 * @param {string} params.tags
+		 * @param {boolean} [params.isStreaming]
 		 * @return {string}
-		 * */
-		unsetEntityTags({ name, tags }) {
-			return assignTemplates(templates.unsetTableTags, { name, tags });
+		 */
+		unsetEntityTags({ name, tags, isStreaming }) {
+			return assignTemplates(templates.unsetTableTags, {
+				name,
+				tags,
+				streaming: isStreaming ? 'STREAMING ' : '',
+			});
 		},
 
 		/**
@@ -458,13 +466,20 @@ module.exports = app => {
 		},
 
 		/**
-		 * @param tableName {string}
-		 * @param columnName {string}
-		 * @param tags {string}
+		 * @param {Object} params
+		 * @param {string} params.tableName
+		 * @param {string} params.columnName
+		 * @param {string} params.tags
+		 * @param {boolean} [params.isStreaming]
 		 * @return {string}
-		 * */
-		setColumnTags({ tableName, columnName, tags }) {
-			return assignTemplates(templates.setColumnTags, { tableName, columnName, tags });
+		 */
+		setColumnTags({ tableName, columnName, tags, isStreaming }) {
+			return assignTemplates(templates.setColumnTags, {
+				tableName,
+				columnName,
+				tags,
+				streaming: isStreaming ? 'STREAMING ' : '',
+			});
 		},
 
 		/**
@@ -473,8 +488,13 @@ module.exports = app => {
 		 * @param tags {string}
 		 * @return {string}
 		 * */
-		unsetColumnTags({ tableName, columnName, tags }) {
-			return assignTemplates(templates.unsetColumnTags, { tableName, columnName, tags });
+		unsetColumnTags({ tableName, columnName, tags, isStreaming }) {
+			return assignTemplates(templates.unsetColumnTags, {
+				tableName,
+				columnName,
+				tags,
+				streaming: isStreaming ? 'STREAMING ' : '',
+			});
 		},
 
 		/**

--- a/forward_engineering/ddlProvider/ddlTemplates.js
+++ b/forward_engineering/ddlProvider/ddlTemplates.js
@@ -74,17 +74,17 @@ module.exports = {
 
 	unsetSchemaTags: 'ALTER SCHEMA ${name}\nUNSET TAGS (${tags});',
 
-	setTableTags: 'ALTER TABLE ${name}\nSET TAGS (${tags});',
+	setTableTags: 'ALTER ${streaming}TABLE ${name}\nSET TAGS (${tags});',
 
-	unsetTableTags: 'ALTER TABLE ${name}\nUNSET TAGS (${tags});',
+	unsetTableTags: 'ALTER ${streaming}TABLE ${name}\nUNSET TAGS (${tags});',
 
 	setViewTags: 'ALTER VIEW ${name}\nSET TAGS (${tags});',
 
 	unsetViewTags: 'ALTER VIEW ${name}\nUNSET TAGS (${tags});',
 
-	setColumnTags: 'ALTER TABLE ${tableName} ALTER COLUMN ${columnName}\nSET TAGS (${tags});',
+	setColumnTags: 'ALTER ${streaming}TABLE ${tableName} ALTER COLUMN ${columnName}\nSET TAGS (${tags});',
 
-	unsetColumnTags: 'ALTER TABLE ${tableName} ALTER COLUMN ${columnName}\nUNSET TAGS (${tags});',
+	unsetColumnTags: 'ALTER ${streaming}TABLE ${tableName} ALTER COLUMN ${columnName}\nUNSET TAGS (${tags});',
 
 	setTableClustering: 'ALTER TABLE ${name} CLUSTER BY ${clustering};',
 

--- a/forward_engineering/helpers/scriptBuilder/feScriptBuilder.js
+++ b/forward_engineering/helpers/scriptBuilder/feScriptBuilder.js
@@ -151,7 +151,6 @@ const getContainerLevelEntitiesScriptDtos =
 		for (const entityId of data.entities) {
 			const entityData = data.entityData[entityId];
 			const tableData = getTab(0, entityData);
-			const isStreaming = tableData?.streamingTable;
 			const dbVersion = data.modelData[0].dbVersion;
 			const likeTableData = data.entityData[tableData?.like];
 			const entityJsonSchema = entitiesJsonSchema[entityId];
@@ -174,18 +173,6 @@ const getContainerLevelEntitiesScriptDtos =
 
 			const indexScript = getIndexes(...createTableStatementArgs);
 
-			let relationshipScripts = [];
-			if (includeRelationshipsInEntityScripts && arePkFkConstraintsAvailable && !isStreaming) {
-				const relationshipsWithThisTableAsChild = data.relationships.filter(
-					relationship => relationship.childCollection === entityId,
-				);
-				relationshipScripts = getCreateRelationshipScripts(app)({
-					relationships: relationshipsWithThisTableAsChild,
-					jsonSchemas: entitiesJsonSchema,
-					relatedSchemas,
-				});
-			}
-
 			const sampleScript = await getSampleScriptForContainerLevelScript({
 				data,
 				entitiesJsonSchema,
@@ -193,7 +180,7 @@ const getContainerLevelEntitiesScriptDtos =
 				includeSamplesInEntityScripts,
 			});
 
-			let tableScript = buildScript([tableStatement, indexScript, ...relationshipScripts]);
+			let tableScript = buildScript([tableStatement, indexScript]);
 			if (sampleScript) {
 				// This is because SQL formatter breaks some "INSERT" statements with complex types
 				tableScript = [tableScript, sampleScript].join('\n');
@@ -263,21 +250,11 @@ const buildContainerLevelFEScriptDto =
 			relatedSchemas,
 		});
 
-		let relationshipScrips = [];
-		if (!includeRelationshipsInEntityScripts && arePkFkConstraintsAvailable) {
-			relationshipScrips = getCreateRelationshipScripts(app)({
-				relationships: data.relationships,
-				jsonSchemas: entitiesJsonSchema,
-				relatedSchemas,
-			});
-		}
-
 		return {
 			catalog: useCatalogStatement,
 			container: databaseStatement,
 			entities: entityScriptDtos,
 			views: viewsScriptDtos,
-			relationships: relationshipScrips,
 		};
 	};
 
@@ -287,7 +264,6 @@ const buildContainerLevelFEScript = containerLevelFEScriptDto => {
 		containerLevelFEScriptDto.container,
 		...containerLevelFEScriptDto.entities.map(e => e.script),
 		...containerLevelFEScriptDto.views.map(v => v.script),
-		...containerLevelFEScriptDto.relationships,
 	]);
 };
 

--- a/forward_engineering/helpers/tableHelper.js
+++ b/forward_engineering/helpers/tableHelper.js
@@ -184,14 +184,20 @@ const getCreateUsingStatement = ({
 	isNotExistsStatement,
 	rowFormatStatement,
 	storedAsStatement,
+	foreignKeyStatement,
 }) => {
+	const isPkOrFkStatement = primaryKeyStatement || foreignKeyStatement;
+
 	return buildStatement(`CREATE${modifiersStatement}TABLE${isNotExistsStatement} ${fullTableName} (`, isActivated)(
 		columnStatement,
-		columnStatement + (primaryKeyStatement ? ',' : ''),
-	)(primaryKeyStatement, primaryKeyStatement)(true, ')')(using, `${getUsing(using)}`)(
-		rowFormatStatement,
-		`ROW FORMAT ${rowFormatStatement}`,
-	)(storedAsStatement, storedAsStatement)(partitionedByKeys, `PARTITIONED BY (${partitionedByKeys})`)(
+		columnStatement + (isPkOrFkStatement ? ',' : ''),
+	)(primaryKeyStatement, primaryKeyStatement + (foreignKeyStatement ? ',' : ''))(
+		foreignKeyStatement,
+		foreignKeyStatement,
+	)(true, ')')(using, `${getUsing(using)}`)(rowFormatStatement, `ROW FORMAT ${rowFormatStatement}`)(
+		storedAsStatement,
+		storedAsStatement,
+	)(partitionedByKeys, `PARTITIONED BY (${partitionedByKeys})`)(
 		!numBuckets && clusteredKeys,
 		`CLUSTER BY (${clusteredKeys})`,
 	)(numBuckets && clusteredKeys, `CLUSTERED BY (${clusteredKeys})`)(
@@ -227,28 +233,30 @@ const getCreateHiveStatement = ({
 	isNotExistsStatement,
 }) => {
 	const isAddBrackets = columnStatement || primaryKeyStatement || foreignKeyStatement;
+	const isPkOrFkStatement = primaryKeyStatement || foreignKeyStatement;
+
 	return buildStatement(`CREATE${modifiersStatement}TABLE${isNotExistsStatement} ${fullTableName} `, isActivated)(
 		isAddBrackets,
 		'(',
-	)(columnStatement, columnStatement + (primaryKeyStatement ? ',' : ''))(primaryKeyStatement, primaryKeyStatement)(
-		foreignKeyStatement,
-		foreignKeyStatement,
-	)(isAddBrackets, ')')(comment, `COMMENT '${encodeStringLiteral(comment)}'`)(
-		partitionedByKeys,
-		`PARTITIONED BY (${partitionedByKeys})`,
-	)(!numBuckets && clusteredKeys, `CLUSTER BY (${clusteredKeys})`)(
-		numBuckets && clusteredKeys,
-		`CLUSTERED BY (${clusteredKeys})`,
-	)(numBuckets && sortedKeys && clusteredKeys, `SORTED BY (${sortedKeys})`)(
-		numBuckets && clusteredKeys,
-		`INTO ${numBuckets} BUCKETS`,
-	)(rowFormatStatement, `ROW FORMAT ${rowFormatStatement}`)(storedAsStatement, storedAsStatement)(
-		location,
-		`LOCATION '${location}'`,
-	)(checkTablePropertiesDefined(tableProperties), `TBLPROPERTIES (${getTablePropertiesClause(tableProperties)})`)(
-		tableOptions,
-		`OPTIONS ${tableOptions}`,
-	)(selectStatement, `AS ${selectStatement}`)(true, ';')();
+	)(columnStatement, columnStatement + (isPkOrFkStatement ? ',' : ''))(
+		primaryKeyStatement,
+		primaryKeyStatement + (foreignKeyStatement ? ',' : ''),
+	)(foreignKeyStatement, foreignKeyStatement)(isAddBrackets, ')')(
+		comment,
+		`COMMENT '${encodeStringLiteral(comment)}'`,
+	)(partitionedByKeys, `PARTITIONED BY (${partitionedByKeys})`)(
+		!numBuckets && clusteredKeys,
+		`CLUSTER BY (${clusteredKeys})`,
+	)(numBuckets && clusteredKeys, `CLUSTERED BY (${clusteredKeys})`)(
+		numBuckets && sortedKeys && clusteredKeys,
+		`SORTED BY (${sortedKeys})`,
+	)(numBuckets && clusteredKeys, `INTO ${numBuckets} BUCKETS`)(
+		rowFormatStatement,
+		`ROW FORMAT ${rowFormatStatement}`,
+	)(storedAsStatement, storedAsStatement)(location, `LOCATION '${location}'`)(
+		checkTablePropertiesDefined(tableProperties),
+		`TBLPROPERTIES (${getTablePropertiesClause(tableProperties)})`,
+	)(tableOptions, `OPTIONS ${tableOptions}`)(selectStatement, `AS ${selectStatement}`)(true, ';')();
 };
 
 const getCreateLikeStatement = ({
@@ -267,19 +275,21 @@ const getCreateLikeStatement = ({
 	tableOptions,
 	likeStatement,
 }) => {
+	const isPkOrFkStatement = primaryKeyStatement || foreignKeyStatement;
+
 	return buildStatement(
 		`CREATE${modifiersStatement}TABLE${isNotExistsStatement} ${fullTableName} ${likeStatement} (`,
 		isActivated,
-	)(columnStatement, columnStatement + (primaryKeyStatement ? ',' : ''))(primaryKeyStatement, primaryKeyStatement)(
-		foreignKeyStatement,
-		foreignKeyStatement,
-	)(true, ')')(using, `${getUsing(using)}`)(rowFormatStatement, `ROW FORMAT ${rowFormatStatement}`)(
-		storedAsStatement,
-		storedAsStatement,
-	)(checkTablePropertiesDefined(tableProperties), `TBLPROPERTIES (${getTablePropertiesClause(tableProperties)})`)(
-		tableOptions,
-		`OPTIONS ${tableOptions}`,
-	)(location, `LOCATION '${location}'`)(true, ';')();
+	)(columnStatement, columnStatement + (isPkOrFkStatement ? ',' : ''))(
+		primaryKeyStatement,
+		primaryKeyStatement + (foreignKeyStatement ? ',' : ''),
+	)(foreignKeyStatement, foreignKeyStatement)(true, ')')(using, `${getUsing(using)}`)(
+		rowFormatStatement,
+		`ROW FORMAT ${rowFormatStatement}`,
+	)(storedAsStatement, storedAsStatement)(
+		checkTablePropertiesDefined(tableProperties),
+		`TBLPROPERTIES (${getTablePropertiesClause(tableProperties)})`,
+	)(tableOptions, `OPTIONS ${tableOptions}`)(location, `LOCATION '${location}'`)(true, ';')();
 };
 
 const getClusteringKeys = (clusteredKeys, deactivatedColumnNames, isParentItemActivated) => {

--- a/forward_engineering/helpers/tableHelper.js
+++ b/forward_engineering/helpers/tableHelper.js
@@ -11,6 +11,7 @@ const {
 	getFullEntityName,
 	getDBVersionNumber,
 	generateFullEntityName,
+	executeUnlessStreaming,
 } = require('../utils/general');
 const { getColumnsStatement, getColumns } = require('./columnHelper');
 const keyHelper = require('./keyHelper');
@@ -546,26 +547,37 @@ const getTableStatement =
 		});
 
 		if (getDBVersionNumber(dbVersion) >= Runtime.MINIMUM_UNITY_TAGS_SUPPORT_VERSION) {
-			const entityUnityTags = getEntityTagsStatement(entityJsonSchema, fullTableName);
+			const entityUnityTags = getEntityTagsStatement(entityJsonSchema, fullTableName, tableData.streamingTable);
 			tableStatement = tableStatement + entityUnityTags;
 		}
 
-		const constraintsStatementsOnColumns = getCheckConstraintsScriptsOnColumnLevel(app)(
-			columns,
-			fullTableName,
-		).join('\n');
-		const constraintsStatementsOnTable = getCheckConstraintsScriptsOnTableLevel(app)(
-			entityJsonSchema,
-			fullTableName,
-		).join('\n');
-		const constraintsStatements = buildConstraints(constraintsStatementsOnTable, constraintsStatementsOnColumns);
+		const constraintsStatements = executeUnlessStreaming(
+			tableData.streamingTable,
+			() => {
+				const constraintsStatementsOnColumns = getCheckConstraintsScriptsOnColumnLevel(app)(
+					columns,
+					fullTableName,
+				).join('\n');
+				const constraintsStatementsOnTable = getCheckConstraintsScriptsOnTableLevel(app)(
+					entityJsonSchema,
+					fullTableName,
+				).join('\n');
+
+				return buildConstraints(constraintsStatementsOnTable, constraintsStatementsOnColumns);
+			},
+			'',
+		);
 
 		if (!_.isEmpty(constraintsStatements)) {
 			tableStatement = tableStatement + `USE ${dbName};\n\n` + constraintsStatements;
 		}
 
 		if (getDBVersionNumber(dbVersion) >= Runtime.MINIMUM_UNITY_TAGS_SUPPORT_VERSION) {
-			const columnsUnityTags = getColumnTagsStatement(entityJsonSchema.properties, fullTableName);
+			const columnsUnityTags = getColumnTagsStatement(
+				entityJsonSchema.properties,
+				fullTableName,
+				tableData.streamingTable,
+			);
 			tableStatement = [tableStatement, ...columnsUnityTags].join('\n');
 		}
 

--- a/forward_engineering/helpers/unityTagsHelper.js
+++ b/forward_engineering/helpers/unityTagsHelper.js
@@ -62,17 +62,19 @@ const getSchemaTagsStatement = (containerData, preparedName) => {
 	return `ALTER SCHEMA ${preparedName} SET TAGS (${tags});`;
 };
 
-const getEntityTagsStatement = (entity, fullTableName) => {
+const getEntityTagsStatement = (entity, fullTableName, isStreaming) => {
 	if (!entity.unityEntityTags?.length) {
 		return '';
 	}
 
 	const tags = buildTagPairs(entity.unityEntityTags);
 
-	return `ALTER TABLE ${fullTableName} SET TAGS (${tags});`;
+	const streamingClause = isStreaming ? 'STREAMING ' : '';
+
+	return `ALTER ${streamingClause}TABLE ${fullTableName} SET TAGS (${tags});`;
 };
 
-const getColumnTagsStatement = (columns, fullTableName) => {
+const getColumnTagsStatement = (columns, fullTableName, isStreaming) => {
 	return _.toPairs(columns)
 		.map(([colName, schema]) => {
 			if (!schema.unityColumnTags?.length) {
@@ -81,7 +83,9 @@ const getColumnTagsStatement = (columns, fullTableName) => {
 
 			const tags = buildTagPairs(schema.unityColumnTags);
 
-			return `ALTER TABLE ${fullTableName} ALTER COLUMN ${colName} SET TAGS (${tags});`;
+			const streamingClause = isStreaming ? 'STREAMING ' : '';
+
+			return `ALTER ${streamingClause}TABLE ${fullTableName} ALTER COLUMN ${colName} SET TAGS (${tags});`;
 		})
 		.filter(Boolean);
 };

--- a/forward_engineering/utils/general.js
+++ b/forward_engineering/utils/general.js
@@ -311,6 +311,23 @@ const checkLiquidClusteringPropertyChanged = compMod => {
 	return !compMod?.numBuckets?.new && compareProperties(compMod.compositeClusteringKey || {});
 };
 
+/**
+ * Executes a task function if the table is not a streaming table.
+ * * This utility is used to separate DDL generation logic between standard and Streaming Tables.
+ * It prevents the execution of operations that are unsupported or restricted on Streaming Tables
+ * (e.g., DROP COLUMN, ALTER CONSTRAINT), ensuring the script remains valid for Delta Live Tables.
+ *
+ * @template T
+ * @param {boolean} isStreaming - Flag indicating if the entity is a streaming table.
+ * @param {() => T} task - The function to execute to generate the script (e.g., () => provider.alterTable(...)).
+ * @param {T} [fallback] - The value to return if isStreaming is true (default is empty string '').
+ * @returns {T} - Returns either the result of the task or the fallback.
+ */
+const executeUnlessStreaming = (isStreaming, task, fallback = '') => {
+	if (isStreaming) return fallback;
+	return task();
+};
+
 module.exports = {
 	buildStatement,
 	getName,
@@ -346,4 +363,5 @@ module.exports = {
 	checkFieldPropertiesChanged,
 	checkLiquidClusteringPropertyChanged,
 	generateFullEntityNameFromBucketAndTableNames,
+	executeUnlessStreaming,
 };


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-14471" title="HCK-14471" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-14471</a>  [Delta Lake-Databricks] FE: Script Generation Options and ALTER clause for streaming tables
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->


## Technical details

- Added inline(in Create statement) FK for DeltaLake
- Deleted duplicated FK Alert statements
- Updated Alter scripts for Streaming tables. 

Most of Alter scripts were muted for Streaming tables. 
**Except**: 
* setTableTags / unsetTableTags
* setColumnTags / unsetColumnTags
Those could work with **STREAMING** keyword
**Syntax Result**: ALTER ${streaming}TABLE ${name} SET TAGS ... 
