### PR TITLE
HCK-14830: add new runtimes 17, 18. Default: 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
                 "Runtime 13",
                 "Runtime 14",
                 "Runtime 15",
-                "Runtime 16"
+                "Runtime 16",
+                "Runtime 17",
+                "Runtime 18"
             ]
         },
         "features": {

--- a/properties_pane/defaultData.json
+++ b/properties_pane/defaultData.json
@@ -1,7 +1,7 @@
 {
 	"model": {
 		"modelName": "New model",
-		"dbVersion": "Runtime 16",
+		"dbVersion": "Runtime 17",
 		"dbVendor": "Delta Lake"
 	},
 	"container": {

--- a/properties_pane/model_level/modelLevelConfig.json
+++ b/properties_pane/model_level/modelLevelConfig.json
@@ -144,7 +144,9 @@ making sure that you maintain a proper JSON format.
 					"Runtime 13",
 					"Runtime 14",
 					"Runtime 15",
-					"Runtime 16"
+					"Runtime 16",
+					"Runtime 17",
+					"Runtime 18"
 				]
 			},
 			{


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-14830" title="HCK-14830" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-14830</a>  [Alpha 8.9.3-2] add Runtime 17 (default) + Runtime 18
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

> [!NOTE]
> No breaking changes identified for 17 and 18

- Added new Databricks runtimes to the Runtime selector. 
- Make Runtime 17 the default runtime version 
...
