### PR TITLE
HCK-14821: streaming tables reordering

### DIFF
--- a/forward_engineering/helpers/scriptBuilder/feScriptBuilder.js
+++ b/forward_engineering/helpers/scriptBuilder/feScriptBuilder.js
@@ -43,7 +43,7 @@
 
 const _ = require('lodash');
 const { getDatabaseStatement, getUseCatalogStatement } = require('../databaseHelper');
-const { getTableStatement } = require('../tableHelper');
+const { getTableStatement, sortEntitiesByStreaming } = require('../tableHelper');
 const { getIndexes } = require('../indexHelper');
 const {
 	buildScript,
@@ -147,7 +147,9 @@ const getContainerLevelEntitiesScriptDtos =
 			relatedSchemas: relatedSchemas,
 		});
 
-		for (const entityId of data.entities) {
+		const sortedEntities = sortEntitiesByStreaming(data.entities, data.entityData);
+
+		for (const entityId of sortedEntities) {
 			const entityData = data.entityData[entityId];
 			const tableData = getTab(0, entityData);
 			const dbVersion = data.modelData[0].dbVersion;

--- a/forward_engineering/helpers/tableHelper.js
+++ b/forward_engineering/helpers/tableHelper.js
@@ -816,6 +816,31 @@ const getCreateStreamingStatement = ({
 	)(true, ';')();
 };
 
+/**
+ * Sorts entities to ensure Standard tables are processed before Streaming tables.
+ * This prevents dependency errors when a Streaming table reads from a Standard table.
+ * * @param {Array<string>} entities - Array of entity IDs
+ * @param {Object} entityData - Object containing entity data
+ * @returns {Array<string>} Sorted array of entity IDs
+ */
+const sortEntitiesByStreaming = (entities, entityData) => {
+	if (!entities || !entityData) return [];
+
+	return [...entities].sort((aId, bId) => {
+		const tableDataA = getTab(0, entityData[aId]);
+		const tableDataB = getTab(0, entityData[bId]);
+
+		const isStreamingA = Boolean(tableDataA?.streamingTable);
+		const isStreamingB = Boolean(tableDataB?.streamingTable);
+
+		if (isStreamingA === isStreamingB) {
+			return 0;
+		}
+
+		return isStreamingA ? 1 : -1;
+	});
+};
+
 module.exports = {
 	getTableStatement,
 	getTablePropertiesClause,
@@ -825,4 +850,5 @@ module.exports = {
 	getPartitionKeyStatement,
 	getClusteringKeys,
 	getPartitionsKeys,
+	sortEntitiesByStreaming,
 };


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-14821" title="HCK-14821" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-14821</a>  [Delta Lake][Streaming tables] Reorder tables in FE tab to put Streaming tables in the bottom of CREATE tables block
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->


## Technical details

We agreed that streaming tables should always be after regular tables in Script. 
This changes the order of entities to do that. 


