### PR TITLE
HCK-15381: fix possible JSON parse error

### DIFF
--- a/reverse_engineering/helpers/fetchRequestHelper.js
+++ b/reverse_engineering/helpers/fetchRequestHelper.js
@@ -400,7 +400,11 @@ const filterCorruptedData = (databasesTablesInfoResult, isTruncatedInMiddle) => 
 	if (isTruncatedInMiddle) {
 		const warningDelimiter = '*** WARNING: max output size exceeded, skipping output. ***';
 		const [firstChunk, lastChunk] = databasesTablesInfoResult.split(warningDelimiter);
-		return [filterCorruptedEnd(firstChunk), filterCorruptedStart(lastChunk)].join(', ');
+		const filteredFirst = filterCorruptedEnd(firstChunk);
+		const filteredLast = filterCorruptedStart(lastChunk);
+		const filteredChunks = [filteredFirst, filteredLast].filter(Boolean);
+		const joined = filteredChunks.join(JSON_OBJECTS_DELIMITER);
+		return filteredLast ? joined : joined + '}]}';
 	}
 
 	return filterCorruptedEnd(databasesTablesInfoResult) + '}]}';


### PR DESCRIPTION
## Content

Fix JSON parse error in `filterCorruptedData` when Databricks response is truncated mid-table

When reverse engineering large schemas, Databricks may truncate API responses by inserting a *** WARNING: max output size exceeded, skipping output. *** marker in the middle of the output. The `filterCorruptedData` function attempts to recover valid JSON by discarding incomplete objects from both sides of the split.

Root cause: Two bugs in the `isTruncatedInMiddle` branch:

- Wrong join delimiter — filtered chunks were joined with ', ' instead of `JSON_OBJECTS_DELIMITER` (`}, {`). This consumed the object boundary, merging two table objects into one and causing silent data loss (duplicate keys resolved by last-wins semantics).

- Empty chunk not handled — when the second chunk contains only a single incomplete table (no }, { delimiter), `filterCorruptedStart` returns an empty string. Joining with ', ' produced a trailing comma ("..., ") which caused `JSON.parse`  to throw: `SyntaxError: Expected double-quoted property name in JSON at position ...`

**Fix:**
- Use `JSON_OBJECTS_DELIMITER` for joining to preserve proper JSON object boundaries
- Filter out empty strings before joining
- Conditionally append `}]}` only when the last chunk contributed no complete tables