### PR TITLE
HCK-15551: improve view column comments

### DIFF
--- a/forward_engineering/config.json
+++ b/forward_engineering/config.json
@@ -561,13 +561,23 @@
 								"exist": false
 							},
 							{
-								"key": "description",
-								"exist": true
+								"type": "or",
+								"values": [
+									{
+										"key": "description",
+										"exist": true
+									},
+									{
+										"key": "refDescription",
+										"exist": true
+									}
+								]
 							}
 						]
 					},
 					"defaultValue": {
-						"description": ""
+						"description": "",
+						"refDescription": ""
 					},
 					"applyToValue": "ignore"
 				},
@@ -593,8 +603,17 @@
 								"exist": false
 							},
 							{
-								"key": "description",
-								"exist": true
+								"type": "or",
+								"values": [
+									{
+										"key": "description",
+										"exist": true
+									},
+									{
+										"key": "refDescription",
+										"exist": true
+									}
+								]
 							},
 							{
 								"type": "not",
@@ -609,7 +628,8 @@
 						]
 					},
 					"defaultValue": {
-						"description": ""
+						"description": "",
+						"refDescription": ""
 					},
 					"applyToValue": "separate"
 				}

--- a/forward_engineering/helpers/viewHelper.js
+++ b/forward_engineering/helpers/viewHelper.js
@@ -101,7 +101,7 @@ function getDefaultColumnList(properties) {
 		.reduce((columnList, [name, property]) => {
 			columnList.push({
 				name: `${prepareName(name)}`,
-				comment: property.description,
+				comment: property.refDescription || property.description,
 				isActivated: property.isActivated,
 			});
 

--- a/reverse_engineering/hqlToCollectionsVisitor.js
+++ b/reverse_engineering/hqlToCollectionsVisitor.js
@@ -396,9 +396,6 @@ class Visitor extends HiveParserVisitor {
 		const { table } = this.visitWhenExists(ctx, 'selectStatementWithCTE', {});
 		const columns = this.visitWhenExists(ctx, 'columnNameCommentList', []);
 		const jsonSchema = convertColumnsToJsonSchema(columns);
-		const columnList = columns
-			.map(column => column.name + (column.comment ? ` COMMENT '${column.comment}'` : ''))
-			.join(', ');
 		const columnNames = columns.map(column => column.name).join(', ');
 		const tableProperties = this.visitWhenExists(ctx, 'tablePropertiesPrefixed');
 
@@ -413,7 +410,7 @@ class Visitor extends HiveParserVisitor {
 			data: {
 				description,
 				tableProperties,
-				columnList,
+				columnList: '',
 			},
 		};
 	}


### PR DESCRIPTION
## Content

- Prioritized reference descriptions (`refDescription`) over definition descriptions (`description`) for view column references
- Removed population of the "Column list" property for reverse engineering of regular views from HQL
  - View columns are now correctly parsed for regular views, so duplicating them in the "Column list" is no longer necessary
  - The property is still populated for materialized views, as they may require a more complex column list
- Added `refDescription` to the script generation options configuration, enabling it to work alongside the existing `description` property