### PR TITLE
fix: missing log

### DIFF
--- a/reverse_engineering/api.js
+++ b/reverse_engineering/api.js
@@ -414,8 +414,8 @@ module.exports = {
 								data.hiddenKeys,
 							);
 						}
-					} catch {
-						logger.log('info', data, `Error parsing ddl statement: \n${ddl}\n`, data.hiddenKeys);
+					} catch (error) {
+						logger.log('info', error, `Error parsing ddl statement: \n${ddl}\n`, data.hiddenKeys);
 						return createViewPackage({ name });
 					}
 


### PR DESCRIPTION
## Technical details

`data` has been used for a long time but it contains connection info so it's ignored in logs. Replace it with the actual `error`