### PR TITLE
HCK-16463: Improve sample data generations for variant types

### DIFF
--- a/forward_engineering/sampleGeneration/mapInsertSampleToDml.js
+++ b/forward_engineering/sampleGeneration/mapInsertSampleToDml.js
@@ -1,4 +1,4 @@
-const { wrapInSingleQuotes } = require('../utils/general');
+const { wrapInSingleQuotes, wrapInParseJsonCall } = require('../utils/general');
 
 /**
  * @typedef {
@@ -104,6 +104,31 @@ const mapJsonObjectToDml = (column, sample) => {
 const mapJsonArrayToDml = (column, sample) => {
 	const stringified = JSON.stringify(sample);
 	return wrapInSingleQuotes(stringified);
+};
+
+/**
+ * Maps a variant sample to a DML string.
+ * @param column {Object}
+ * @param sample {any}
+ * @returns {string}
+ * */
+const mapVariantToDml = (column, sample) => {
+	switch (column.subtype) {
+		case 'object':
+			return wrapInParseJsonCall(mapJsonObjectToDml(column, sample));
+		case 'array':
+			return wrapInParseJsonCall(mapJsonArrayToDml(column, sample));
+		case 'string':
+			return mapStringToDml(column, sample);
+		case 'number':
+			return mapNumberToDml(column, sample);
+		case 'boolean':
+			return mapBooleanToDml(column, sample);
+		case 'null':
+			return 'NULL';
+		default:
+			return sample.toString();
+	}
 };
 
 /**
@@ -225,7 +250,8 @@ const typeToMapperMap = new Map()
 	.set('array', mapArrayToDml)
 	.set('struct', mapStructToDml)
 	.set('jsonObject', mapJsonObjectToDml)
-	.set('jsonArray', mapJsonArrayToDml);
+	.set('jsonArray', mapJsonArrayToDml)
+	.set('variant', mapVariantToDml);
 
 /**
  * @param column {Object}

--- a/forward_engineering/sampleGeneration/mapInsertSampleToDml.js
+++ b/forward_engineering/sampleGeneration/mapInsertSampleToDml.js
@@ -113,21 +113,23 @@ const mapJsonArrayToDml = (column, sample) => {
  * @returns {string}
  * */
 const mapVariantToDml = (column, sample) => {
+	const sampleValue = column.sample || sample;
+
 	switch (column.subtype) {
 		case 'object':
-			return wrapInParseJsonCall(mapJsonObjectToDml(column, sample));
+			return wrapInParseJsonCall(mapJsonObjectToDml(column, sampleValue));
 		case 'array':
-			return wrapInParseJsonCall(mapJsonArrayToDml(column, sample));
+			return wrapInParseJsonCall(mapJsonArrayToDml(column, sampleValue));
 		case 'string':
-			return mapStringToDml(column, sample);
+			return mapStringToDml(column, sampleValue);
 		case 'number':
-			return mapNumberToDml(column, sample);
+			return mapNumberToDml(column, sampleValue);
 		case 'boolean':
-			return mapBooleanToDml(column, sample);
+			return mapBooleanToDml(column, sampleValue);
 		case 'null':
 			return 'NULL';
 		default:
-			return sample.toString();
+			return sampleValue.toString();
 	}
 };
 

--- a/forward_engineering/utils/general.js
+++ b/forward_engineering/utils/general.js
@@ -151,6 +151,10 @@ const wrapInBrackets = (str = '') => {
 	return /^\(.*\)$/.test(str) ? str : `(${str})`;
 };
 
+const wrapInParseJsonCall = (str = '') => {
+	return `parse_json(${str})`;
+};
+
 /**
  * @param statements {Array<string>}
  * */
@@ -340,6 +344,7 @@ module.exports = {
 	buildScript,
 	wrapInSingleQuotes,
 	wrapInBrackets,
+	wrapInParseJsonCall,
 	getEntityData,
 	getFullEntityName,
 	generateFullEntityName,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1302,6 +1302,7 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"esbuild": "bin/esbuild"
 			},
@@ -2008,6 +2009,7 @@
 			"integrity": "sha512-EEHNdo5cW2w1xwYdBQ7d3IXDqWAtMkfVFrh+9gQ4kYbYJwygY4QXSh1eH80/xVipZdVKujAwBgg/nNNHk56kxQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"tsgolint": "bin/tsgolint.js"
 			},
@@ -2137,6 +2139,7 @@
 			"integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"prettier": "bin/prettier.cjs"
 			},


### PR DESCRIPTION
## Content

Added a helper to generate sample data for variant subtype. 

## Technical details

Before the fix, we used to call `sample.toString()`.  It was producing an error when subtype is NULL. 